### PR TITLE
help2man dependency for ubuntu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,8 @@ dnl AC_DEFINE writes values in config.h
 dnl AC_DEFINE_UNQUOTED performs additional shell expansions, e.g. substitution
 dnl of variable with value.
 
-AM_MISSING_PROG(HELP2MAN, help2man)
+AC_CHECK_PROG([have_help2man], [help2man], [yes], [no])
+AM_CONDITIONAL([HAVE_HELP2MAN], [test x$have_help2man = xyes])
 
 ENABLE_AUTO([all],
             [all renderers (use --enable-xyz to re-enable certain renderers)],

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -5,7 +5,9 @@
 ## comments starting with a single # are copied to Makefile.in (and afterwards
 ## to Makefile), comments with ## are dropped.
 
+if HAVE_HELP2MAN
 dist_man_MANS = $(SSR_executables:=.1)
+endif
 
 MAINTAINERCLEANFILES = $(dist_man_MANS)
 
@@ -21,7 +23,7 @@ RENDERER_TEXT = "manual page for the \
 # "make" must be called before "make dist", there is no automatic dependency!
 
 $(dist_man_MANS): $(top_srcdir)/src/configuration.cpp $(top_srcdir)/configure.ac
-	$(HELP2MAN) --no-info --name=$(RENDERER_TEXT) --output=$@ --locale=en \
+	help2man --no-info --name=$(RENDERER_TEXT) --output=$@ --locale=en \
 		$(top_builddir)/src/$(@:.1=$(EXEEXT))
 
 ## Settings for Vim (http://www.vim.org/), please do not remove:


### PR DESCRIPTION
help2man is missing, compiling aborts. Installing fixes it. Tested on Ubuntu 14.04 and 15.10.