### PR TITLE
Fix centered WFS source

### DIFF
--- a/src/wfsrenderer.h
+++ b/src/wfsrenderer.h
@@ -375,6 +375,14 @@ WfsRenderer::RenderFunction::select(SourceChannel& in)
           auto lhs = ls.position - src_pos;
           auto rhs = ref_off.position - src_pos;
 
+          // rhs will be zero if src_pos is exactly at the reference position
+          // This would would lead to the inner product being zero.
+          // lhs can't be zero (checked before to avoid infinite gain)
+          if (rhs.x == 0.0f && rhs.y == 0.0f)
+          {
+            rhs.y = -0.001;
+          }
+
           // TODO: write inner product function in Position class
           if ((lhs.x * rhs.x + lhs.y * rhs.y) < 0.0f)
           {


### PR DESCRIPTION
Sources in WFS won’t play at all if it is initialized exactly at the
reference point. This checks whether _rhs_ (distance between source and
ref_point) == 0 and simply sets _rhs_ to be  -0.001 (effectively moving the source 0.001 in the positive y direction).
