### PR TITLE
Source properties are Qt5 ready

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -464,7 +464,7 @@ dnl enable/disable GUI, default: enabled
 ENABLE_FORCED([gui], [graphical user interface (using Qt)],
 [
   # Checking for Qt
-  PKG_CHECK_MODULES([QT], [QtCore >= 4.2.2 QtGui >= 4.2.2 QtOpenGL >= 4.2.2]
+  PKG_CHECK_MODULES([QT], [Qt5Core >= 5.0.0 Qt5Gui >= 5.0.0 Qt5OpenGL >= 5.0.0]
     ,
     , [have_gui=no])
 
@@ -494,16 +494,16 @@ AS_IF([test x$have_gui = xyes],
     QTMOC="moc"
   ],
   [
-    QTMOC=`$PKG_CONFIG --variable=moc_location QtCore`
+    QTMOC=`$PKG_CONFIG --variable=moc_location Qt5Core`
   ])
-  QTLIBDIR=`$PKG_CONFIG --variable=libdir QtGui`
+  QTLIBDIR=`$PKG_CONFIG --variable=libdir Qt5Gui`
 
   AC_SUBST(QTMOC)
   AC_SUBST(QTLIBDIR)
   AC_SUBST(MOCFLAGS)
 
   # check if floating control panel has to be forced
-  PKG_CHECK_MODULES([QtGui_4_7_or_higher], [QtGui >= 4.7.0],
+  PKG_CHECK_MODULES([QtGui_5_0_or_higher], [Qt5Gui >= 5.0.0],
   [
     AS_IF([test x$enable_floating_control_panel = xno],
     [

--- a/configure.ac
+++ b/configure.ac
@@ -488,7 +488,7 @@ AS_IF([test x$have_gui = xyes],
   # settings for Qt
   LIBS="$LIBS $QT_LIBS"
   PKG_FLAGS="$PKG_FLAGS $QT_CFLAGS"
-  AC_MSG_CHECKING([Do we have to add -fPIC flag to make Qt happy])
+  AC_MSG_CHECKING([if we have to add -fPIC to make Qt happy])
   CPPFLAGS_backup="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $QT_CFLAGS"
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(

--- a/configure.ac
+++ b/configure.ac
@@ -502,19 +502,8 @@ AS_IF([test x$have_gui = xyes],
   AC_SUBST(QTLIBDIR)
   AC_SUBST(MOCFLAGS)
 
-  # check if floating control panel has to be forced
-  PKG_CHECK_MODULES([QtGui_5_0_or_higher], [Qt5Gui >= 5.0.0],
-  [
-    AS_IF([test x$enable_floating_control_panel = xno],
-    [
-      AC_MSG_ERROR([With Qt >= 4.7 the floating control panel is obligatory!])
-    ],
-    [test x$enable_floating_control_panel = x],
-    [
-      AC_MSG_WARN([Found Qt >= 4.7, forcing --enable-floating-control-panel!])
-      enable_floating_control_panel=yes
-    ])
-  ], [true])
+  # enable floating control panel, as it is the only option on qt5
+  enable_floating_control_panel=yes
 ])
 
 ENABLE_EXPLICIT([floating-control-panel], [separate control window],

--- a/configure.ac
+++ b/configure.ac
@@ -487,8 +487,8 @@ AS_IF([test x$have_gui = xyes],
 [
   # settings for Qt
   LIBS="$LIBS $QT_LIBS"
-  # add -fPIC flag to satisfy qt on linux
-  AC_MSG_CHECKING([Checking whether we have to add -fPIC flag to make Qt happy - ])
+  PKG_FLAGS="$PKG_FLAGS $QT_CFLAGS"
+  AC_MSG_CHECKING([Do we have to add -fPIC flag to make Qt happy])
   CPPFLAGS_backup="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $QT_CFLAGS"
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(

--- a/configure.ac
+++ b/configure.ac
@@ -487,7 +487,19 @@ AS_IF([test x$have_gui = xyes],
 [
   # settings for Qt
   LIBS="$LIBS $QT_LIBS"
-  PKG_FLAGS="$PKG_FLAGS $QT_CFLAGS"
+  # add -fPIC flag to satisfy qt on linux
+  AC_MSG_CHECKING([Checking whether we have to add -fPIC flag to make Qt happy - ])
+  CPPFLAGS_backup="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $QT_CFLAGS"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+  [
+    #include <QtCore/QObject>
+  ], [])], AC_MSG_RESULT([no]),
+  [
+    AC_MSG_RESULT([yes])
+    PKG_FLAGS="$PKG_FLAGS -fPIC"
+  ])
+  CPPFLAGS="$CPPFLAGS_backup"
   MOCFLAGS="$QT_CFLAGS"
   AS_IF([which moc 2>&1 >/dev/null],
   [

--- a/data/MacOSX/Makefile.am
+++ b/data/MacOSX/Makefile.am
@@ -48,21 +48,29 @@ install-exec-hook:
 		$(srcdir)/run-ssr.applescript
 
 install-data-hook:
-	cp -r $(QTLIBDIR)/QtGui.framework/Resources/qt_menu.nib $(DESTDIR)$(pkgdatadir)/
+	mkdir -p $(DESTDIR)$(contentsdir)/PlugIns/platforms
+	cp -f `qmake -query QT_INSTALL_PLUGINS`/platforms/libqcocoa.dylib $(DESTDIR)$(contentsdir)/PlugIns/platforms
+	install_name_tool -id @executable_path/../PlugIns/platforms/libqcocoa.dylib $(DESTDIR)$(contentsdir)/PlugIns/platforms/libqcocoa.dylib
+
 	-cd $(DESTDIR)$(dmgrootdir) && $(LN_S) /Applications
-	for qtc in QtGui QtCore QtOpenGL; do \
-		mkdir -p $(prefix)/Frameworks/$$qtc.framework/Versions/4 \
-		; cp $(QTLIBDIR)/$$qtc.framework/Versions/4/$$qtc $(prefix)/Frameworks/$$qtc.framework/Versions/4/ \
-		; install_name_tool -id @executable_path/../Frameworks/Versions/4/$$qtc.framework/$$qtc $(prefix)/Frameworks/$$qtc.framework/Versions/4/$$qtc \
+	for qtc in QtGui QtCore QtOpenGL QtWidgets QtPrintSupport; do \
+		install_name_tool -change $(QTLIBDIR)/$$qtc.framework/Versions/5/$$qtc @executable_path/../Frameworks/$$qtc.framework/Versions/5/$$qtc $(DESTDIR)$(contentsdir)/PlugIns/platforms/libqcocoa.dylib \
+		; mkdir -p $(prefix)/Frameworks/$$qtc.framework/Versions/5 \
+		; cp $(QTLIBDIR)/$$qtc.framework/Versions/5/$$qtc $(prefix)/Frameworks/$$qtc.framework/Versions/5/ \
+		; chmod +w $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
+		; install_name_tool -id @executable_path/../Frameworks/Versions/5/$$qtc.framework/$$qtc $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
+		; install_name_tool -change $(QTLIBDIR)/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
+		; install_name_tool -change $(QTLIBDIR)/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
+		; install_name_tool -change $(QTLIBDIR)/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
 	; done
+
 	for exec in $(SSR_executables); do \
-		install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/4/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/4/QtCore $(prefix)/MacOS/$$exec \
-		; install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/4/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/4/QtGui $(prefix)/MacOS/$$exec \
-		; install_name_tool -change /usr/local/opt/qt/lib/QtOpenGL.framework/Versions/4/QtOpenGL @executable_path/../Frameworks/QtOpenGL.framework/Versions/4/QtOpenGL $(prefix)/MacOS/$$exec \
+		install_name_tool -change /usr/local/opt/qt5/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore $(prefix)/MacOS/$$exec \
+		; install_name_tool -change /usr/local/opt/qt5/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui $(prefix)/MacOS/$$exec \
+		; install_name_tool -change /usr/local/opt/qt5/lib/QtOpenGL.framework/Versions/5/QtOpenGL @executable_path/../Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL $(prefix)/MacOS/$$exec \
+		; install_name_tool -change /usr/local/opt/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets $(prefix)/MacOS/$$exec \
+		; install_name_tool -change /usr/local/opt/qt5/lib/QtPrintSupport.framework/Versions/5/QtPrintSupport @executable_path/../Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport $(prefix)/MacOS/$$exec \
 	; done
-	install_name_tool -change $(QTLIBDIR)/QtCore.framework/Versions/4/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/4/QtCore $(prefix)/Frameworks/QtGui.framework/Versions/4/QtGui
-	install_name_tool -change $(QTLIBDIR)/QtCore.framework/Versions/4/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/4/QtCore $(prefix)/Frameworks/QtOpenGL.framework/Versions/4/QtOpenGL
-	install_name_tool -change $(QTLIBDIR)/QtGui.framework/Versions/4/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/4/QtGui $(prefix)/Frameworks/QtOpenGL.framework/Versions/4/QtOpenGL
 
 # create a DMG image
 dmg:

--- a/data/MacOSX/Makefile.am
+++ b/data/MacOSX/Makefile.am
@@ -63,7 +63,6 @@ install-data-hook:
 		; install_name_tool -change $(QTLIBDIR)/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
 		; install_name_tool -change $(QTLIBDIR)/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
 		; install_name_tool -change $(QTLIBDIR)/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets $(prefix)/Frameworks/$$qtc.framework/Versions/5/$$qtc \
-
 	; done
 
 	for exec in $(SSR_executables); do \

--- a/data/MacOSX/Makefile.am
+++ b/data/MacOSX/Makefile.am
@@ -36,7 +36,8 @@ dist_noinst_DATA = dylibbundler/index.html dylibbundler/makefile \
 
 # this is done after installing the executable
 install-exec-hook:
-	cp `which ecasound` $(DESTDIR)$(bindir)
+	cp -f `which ecasound` $(DESTDIR)$(bindir)
+	chmod +w $(DESTDIR)$(bindir)/ecasound
 	for exec in $(SSR_executables) ecasound; do \
 		$(builddir)/dylibbundler/dylibbundler \
 		--create-dir --overwrite-files --bundle-deps \

--- a/data/MacOSX/qt.conf
+++ b/data/MacOSX/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Plugins = PlugIns

--- a/doc/manual/operation.rst
+++ b/doc/manual/operation.rst
@@ -151,7 +151,7 @@ code and compile each program yourself.
 - **make**
 - **g++** (at least version 4.7.3) or **clang**
 - **libasio-dev**
-- **libqt4-dev** and **libqt4-opengl-dev** (at least version 4.2.2)
+- **qtbase5-dev** and **libqt5opengl5-dev** (To build the GUI)
 - **libecasoundc2.2-dev** or **libecasoundc-dev**
 - **ecasound**
 - **libxml2-dev**
@@ -653,7 +653,7 @@ These ports have to be installed (dependencies are installed automatically)
 - libsndfile
 - libsamplerate
 - fftw-3-single
-- qt4-mac
+- qt5-mac
 - libxml2
 
 If you want, you can also use clang instead of GCC to compile the SSR.
@@ -671,7 +671,7 @@ Ports are installed using ::
 Because ports are compiled locally, it may take a long time to install all
 ports. Issuing one command to install all ports might be more convenient::
 
-  sudo sh -c "port install gcc49 && port install pkgconfig && port install libsndfile && port install libsamplerate && port install fftw-3-single && port install qt4-mac && port install libxml2"
+  sudo sh -c "port install gcc49 && port install pkgconfig && port install libsndfile && port install libsamplerate && port install fftw-3-single && port install qt5-mac && port install libxml2"
 
 Lastly, you need to install the asio library if you want to compile with the network
 interface. You can download it from: http://think-async.com
@@ -1242,10 +1242,10 @@ similar, depending on the exact Qt installation).
 
   install_name_tool -id /opt/local/lib/libQtCore.dylib /opt/local/Library/Frameworks/QtCore.framework/QtCore
   install_name_tool -id /opt/local/lib/libQtGui.dylib /opt/local/Library/Frameworks/QtGui.framework/QtGui
-  install_name_tool -change /opt/local/Library/Frameworks/QtCore.framework/Versions/4/QtCore /opt/local/lib/libQtCore.dylib /opt/local/Library/Frameworks/QtGui.framework/QtGui
+  install_name_tool -change /opt/local/Library/Frameworks/QtCore.framework/Versions/5/QtCore /opt/local/lib/libQtCore.dylib /opt/local/Library/Frameworks/QtGui.framework/QtGui
   install_name_tool -id /opt/local/lib/libQtOpenGL.dylib /opt/local/Library/Frameworks/QtOpenGL.framework/QtOpenGL
-  install_name_tool -change /opt/local/Library/Frameworks/QtCore.framework/Versions/4/QtCore /opt/local/lib/libQtCore.dylib /opt/local/Library/Frameworks/QtOpenGL.framework/QtOpenGL
-  install_name_tool -change /opt/local/Library/Frameworks/QtGui.framework/Versions/4/QtGui /opt/local/lib/libQtGui.dylib /opt/local/Library/Frameworks/QtOpenGL.framework/QtOpenGL
+  install_name_tool -change /opt/local/Library/Frameworks/QtCore.framework/Versions/5/QtCore /opt/local/lib/libQtCore.dylib /opt/local/Library/Frameworks/QtOpenGL.framework/QtOpenGL
+  install_name_tool -change /opt/local/Library/Frameworks/QtGui.framework/Versions/5/QtGui /opt/local/lib/libQtGui.dylib /opt/local/Library/Frameworks/QtOpenGL.framework/QtOpenGL
 
 You need the appropriate rights to change the library files, so you probably
 need to use ``sudo`` before the commands.
@@ -1261,8 +1261,8 @@ To get some information about a library, you can try something like those::
 SSR for Mac OS X: qt_menu.nib not found
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This was fixed in MacPorts, see https://trac.macports.org/ticket/37662. Thanks
-to Chris Pike!
+This was fixed in MacPorts, see https://trac.macports.org/ticket/37662. Thanks to Chris Pike!
+Since version 0.5 (switching to qt5), qt_menu.nib is not needed any more.
 
 Compilation Error on Ubuntu and Archlinux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1303,6 +1303,7 @@ Missing GUI Buttons and Timeline
 
 This issue was resolved in version 0.3.2, the default setting for ``--enable-
 floating-control-panel`` is chosen depending on the installed Qt version.
+As of version 0.5 (switching to qt5), the floating control panel is always enabled.
 
 Different versions of Qt show different behaviour regarding OpenGL Overlays
 and as a result, the GUI buttons are not shown in newer Qt versions.

--- a/src/gui/qclicktextlabel.h
+++ b/src/gui/qclicktextlabel.h
@@ -30,8 +30,8 @@
 #ifndef SSR_QCLICKTEXTLABEL_H
 #define SSR_QCLICKTEXTLABEL_H
 
-#include <QLabel>
-#include <QMouseEvent>
+#include <QtGui/QMouseEvent>
+#include <QtWidgets/QLabel>
 
 /// QClickTextLabel
 class QClickTextLabel : public QLabel

--- a/src/gui/qcpulabel.cpp
+++ b/src/gui/qcpulabel.cpp
@@ -26,10 +26,10 @@
 
 /// @file
 /// TODO: add description
-
-#include <QPainter>
-#include <QTimer>
 #include <algorithm>
+
+#include <QtCore/QTimer>
+#include <QtGui/QPainter>
 
 #include "qcpulabel.h"
 

--- a/src/gui/qcpulabel.h
+++ b/src/gui/qcpulabel.h
@@ -30,8 +30,8 @@
 #ifndef SSR_QCPULABEL_H
 #define SSR_QCPULABEL_H
 
-#include <QLabel>
-#include <QPaintEvent>
+#include <QtGui/QPaintEvent>
+#include <QtWidgets/QLabel>
 
 /// QCPULabel
 class QCPULabel : public QLabel

--- a/src/gui/qfilemenulabel.cpp
+++ b/src/gui/qfilemenulabel.cpp
@@ -27,7 +27,7 @@
 /// @file
 /// TODO: add description
 
-#include <QPainter>
+#include <QtGui/QPainter>
 
 #include "qfilemenulabel.h"
 

--- a/src/gui/qfilemenulabel.h
+++ b/src/gui/qfilemenulabel.h
@@ -30,8 +30,9 @@
 #ifndef SSR_QFILEMENULABEL_H
 #define SSR_QFILEMENULABEL_H
 
+#include <QtGui/QMouseEvent>
+
 #include "qclicktextlabel.h"
-#include <QMouseEvent>
 
 /// QFileMenuLabel
 class QFileMenuLabel : public QClickTextLabel

--- a/src/gui/qgui.cpp
+++ b/src/gui/qgui.cpp
@@ -231,11 +231,9 @@ int ssr::QGUI::run()
   // TODO: check return values
   _gui.show();
   
-#ifdef __APPLE__
   // bring window to front
   _gui.raise();
   _gui.activateWindow();
-#endif
 
   // TODO: check if _qt_app is valid
   _qt_app.connect(&_qt_app, SIGNAL(lastWindowClosed()), &_qt_app, SLOT(quit()));

--- a/src/gui/qgui.h
+++ b/src/gui/qgui.h
@@ -30,9 +30,9 @@
 #ifndef SSR_QGUI_H
 #define SSR_QGUI_H
 
-#include <QObject>
-#include <QApplication>
-#include <QGLFormat>
+#include <QtCore/QObject>
+#include <QtOpenGL/QGLFormat>
+#include <QtWidgets/QApplication>
 
 #include "quserinterface.h"
 #include "publisher.h"

--- a/src/gui/qguiframe.h
+++ b/src/gui/qguiframe.h
@@ -30,10 +30,10 @@
 #ifndef SSR_QGUIFRAME_H
 #define SSR_QGUIFRAME_H
 
-#include <QWidget>
-#include <QTimer>
-#include <QLabel>
-#include <QMouseEvent>
+#include <QtCore/QTimer>
+#include <QtGui/QMouseEvent>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QWidget>
 
 //#include "qclicktextlabel.h"
 

--- a/src/gui/qopenglplotter.cpp
+++ b/src/gui/qopenglplotter.cpp
@@ -29,19 +29,20 @@
 
 #include <stdio.h>
 #include <stdarg.h>
-#include <QAction>
-#include <QDialog>
-#include <QLineEdit>
-#include <QSlider>
-#include <QSize>
-#include <QPushButton>
-#include <QRect>
-#include <QImage>
-#include <QMouseEvent>
-#include <QCloseEvent>
-#include <QPoint>
-#include <QMenu>
 #include <cmath>
+
+#include <QtCore/QPoint>
+#include <QtCore/QRect>
+#include <QtCore/QSize>
+#include <QtGui/QCloseEvent>
+#include <QtGui/QImage>
+#include <QtGui/QMouseEvent>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QSlider>
 
 #include "qopenglplotter.h"
 #include "qclicktextlabel.h"
@@ -142,7 +143,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
 
   if (!image_buffer.isNull()) _ssr_logo_texture = bindTexture(image_buffer);
   else 
-    ERROR("Texture \"" << path_to_image.toAscii().data() << "\" not loaded.");
+    ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
 
   image_buffer = QImage(); 
 
@@ -157,7 +158,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
     _source_shadow_texture = bindTexture(image_buffer);
   }
   else 
-    ERROR("Texture \"" << path_to_image.toAscii().data() << "\" not loaded.");
+    ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
 
   if (_controller.show_head())
   {
@@ -173,7 +174,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
 
     if (!image_buffer.isNull()) _listener_texture = bindTexture(image_buffer);
     else 
-     ERROR("Texture \"" << path_to_image.toAscii().data() << "\" not loaded.");
+     ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
 
     // load listener shadow texture
     image_buffer = QImage();
@@ -188,7 +189,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
       _listener_shadow_texture = bindTexture(image_buffer);
     }
     else 
-     ERROR("Texture \"" << path_to_image.toAscii().data() << "\" not loaded.");
+     ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
 
     // load listener background texture
     image_buffer = QImage();
@@ -203,7 +204,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
       _listener_background_texture = bindTexture(image_buffer);
     }
     else 
-     ERROR("Texture \"" << path_to_image.toAscii().data() << "\" not loaded.");
+     ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
 
   }
 

--- a/src/gui/qopenglplotter.cpp
+++ b/src/gui/qopenglplotter.cpp
@@ -143,7 +143,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
 
   if (!image_buffer.isNull()) _ssr_logo_texture = bindTexture(image_buffer);
   else 
-    ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
+    ERROR("Texture \"" << path_to_image.toUtf8().data() << "\" not loaded.");
 
   image_buffer = QImage(); 
 
@@ -158,7 +158,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
     _source_shadow_texture = bindTexture(image_buffer);
   }
   else 
-    ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
+    ERROR("Texture \"" << path_to_image.toUtf8().data() << "\" not loaded.");
 
   if (_controller.show_head())
   {
@@ -174,7 +174,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
 
     if (!image_buffer.isNull()) _listener_texture = bindTexture(image_buffer);
     else 
-     ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
+     ERROR("Texture \"" << path_to_image.toUtf8().data() << "\" not loaded.");
 
     // load listener shadow texture
     image_buffer = QImage();
@@ -189,7 +189,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
       _listener_shadow_texture = bindTexture(image_buffer);
     }
     else 
-     ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
+     ERROR("Texture \"" << path_to_image.toUtf8().data() << "\" not loaded.");
 
     // load listener background texture
     image_buffer = QImage();
@@ -204,7 +204,7 @@ void ssr::QOpenGLPlotter::_load_background_textures()
       _listener_background_texture = bindTexture(image_buffer);
     }
     else 
-     ERROR("Texture \"" << path_to_image.toLatin1().data() << "\" not loaded.");
+     ERROR("Texture \"" << path_to_image.toUtf8().data() << "\" not loaded.");
 
   }
 

--- a/src/gui/qopenglplotter.cpp
+++ b/src/gui/qopenglplotter.cpp
@@ -122,6 +122,9 @@ ssr::QOpenGLPlotter::QOpenGLPlotter(Publisher& controller, const Scene& scene
   _color_vector.push_back(QColor(173, 54, 35));
   //_color_vector.push_back(QColor(242,226, 22));  // yellow is too hard to read
 
+  // detect HDPI display
+  m_scale = this->devicePixelRatio();
+
 }
 
 ssr::QOpenGLPlotter::~QOpenGLPlotter()

--- a/src/gui/qopenglplotter.h
+++ b/src/gui/qopenglplotter.h
@@ -36,15 +36,15 @@
 #include <GL/glu.h>
 #endif
 
-#include <QGLWidget>
-#include <QAction>
-#include <QString>
-#include <QWidget>
-#include <QImage>
-#include <QMouseEvent>
-#include <QKeyEvent>
-#include <QCloseEvent>
-#include <QLabel>
+#include <QtOpenGL/QGLWidget>
+#include <QtWidgets/QAction>
+#include <QtCore/QString>
+#include <QtWidgets/QWidget>
+#include <QtGui/QImage>
+#include <QtGui/QMouseEvent>
+#include <QtGui/QKeyEvent>
+#include <QtGui/QCloseEvent>
+#include <QtWidgets/QLabel>
 #include <vector>
 #include <list>
 #include <map>

--- a/src/gui/qscenebutton.cpp
+++ b/src/gui/qscenebutton.cpp
@@ -27,7 +27,7 @@
 /// @file
 /// TODO: add description
 
-#include <QPainter>
+#include <QtGui/QPainter>
 
 #include "qscenebutton.h"
 

--- a/src/gui/qscenebutton.h
+++ b/src/gui/qscenebutton.h
@@ -30,8 +30,8 @@
 #ifndef SSR_QSCENEBUTTON_H
 #define SSR_QSCENEBUTTON_H
 
-#include <QPushButton>
-#include <QMouseEvent>
+#include <QtGui/QMouseEvent>
+#include <QtWidgets/QPushButton>
 
 /// QSceneButton
 class QSceneButton : public QPushButton

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -27,8 +27,8 @@
 /// @file
 /// TODO: add description
 
-#include <QPalette> 
-#include <QSizePolicy>
+#include <QtGui/QPalette> 
+#include <QtWidgets/QSizePolicy>
 
 #include "qsourceproperties.h"
 

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -343,7 +343,7 @@ void QSourceProperties::update_displays(const Source& source,
   {
     _properties_display->setText(source.properties_file.c_str());
   }
-  this->raise();
+
 }
 
 void QSourceProperties::_expand()

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -43,11 +43,7 @@ using namespace apf::math;
 //#define ROWHEIGHT 40
 
 QSourceProperties::QSourceProperties(QWidget* parent)
-#ifdef __APPLE__
 : QFrame(parent, Qt::Window | Qt::CustomizeWindowHint),
-#else
-    : QFrame(parent),
-#endif
     _create_new_source(false)
 {
   this->setAutoFillBackground(true);

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -343,7 +343,7 @@ void QSourceProperties::update_displays(const Source& source,
   {
     _properties_display->setText(source.properties_file.c_str());
   }
-
+  this->raise();
 }
 
 void QSourceProperties::_expand()

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -43,11 +43,7 @@ using namespace apf::math;
 //#define ROWHEIGHT 40
 
 QSourceProperties::QSourceProperties(QWidget* parent)
-#ifdef __APPLE__
 : QFrame(parent, Qt::Window | Qt::CustomizeWindowHint),
-#else
-    : QFrame(parent),
-#endif
     _create_new_source(false)
 {
   this->setAutoFillBackground(true);
@@ -347,7 +343,7 @@ void QSourceProperties::update_displays(const Source& source,
   {
     _properties_display->setText(source.properties_file.c_str());
   }
-
+this->raise();
 }
 
 void QSourceProperties::_expand()
@@ -417,20 +413,7 @@ void QSourceProperties::_set_doppler(bool flag)
   //emit signal_set_source_property( );
 }
 
-bool QSourceProperties::event(QEvent *e)
-{
-  // catch mouse events
-  if (e->type() == QEvent::MouseButtonDblClick ||
-      e->type() == QEvent::MouseButtonPress ||
-      e->type() == QEvent::MouseButtonRelease ||
-      e->type() == QEvent::MouseMove)
-  {
-    e->accept();
-    return true;
-  }
-  else return false;
 
-}
 // Settings for Vim (http://www.vim.org/), please do not remove:
 // vim:softtabstop=2:shiftwidth=2:expandtab:textwidth=80:cindent
 // vim:fdm=expr:foldexpr=getline(v\:lnum)=~'/\\*\\*'&&getline(v\:lnum)!~'\\*\\*/'?'a1'\:getline(v\:lnum)=~'\\*\\*/'&&getline(v\:lnum)!~'/\\*\\*'?'s1'\:'='

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -27,7 +27,7 @@
 /// @file
 /// TODO: add description
 
-#include <QtGui/QPalette> 
+#include <QtGui/QPalette>
 #include <QtWidgets/QSizePolicy>
 
 #include "qsourceproperties.h"
@@ -71,13 +71,13 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _name_display->setFrame(false);
   _name_display->setReadOnly(true);
   _name_display->setFocusPolicy(Qt::NoFocus);
-  
+
   _grid->addWidget(_name_display, current_row, 1, 1, 1);
 
   current_row++;
 
   // coordinates
-  
+
   _grid->addWidget(_create_text_label("<font color=\"#888888\">x, y</font>"), current_row, 0);
 
   _coordinates_display = new QLabel();
@@ -88,7 +88,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _grid->addWidget(_create_text_label(" mtrs"), current_row, 2);
 
   current_row++;
-  
+
   // distance
 
   _grid->addWidget(_create_text_label("<font color=\"#888888\">distance</font>"), current_row, 0);
@@ -112,7 +112,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
 
   _grid->addWidget(_azimuth_display, current_row, 1);
   _grid->addWidget(_create_text_label(" degs"), current_row, 2);
-  
+
   current_row++;
 
   // position fix
@@ -124,7 +124,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   connect(_position_fix_box, SIGNAL( toggled(bool) ), this, SLOT( _set_source_position_fixed(bool) ));
 
   _grid->addWidget(_position_fix_box, current_row, 2, Qt::AlignLeft);
- 
+
   current_row++;
 
   // doppler effect enabled
@@ -136,7 +136,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   //connect(_doppler_box, SIGNAL( toggled(bool) ), this, SLOT( _set_doppler(bool) ));
 
   //_grid->addWidget(_doppler_box, current_row, 2, Qt::AlignLeft);
- 
+
   //current_row++;
 
   // volume
@@ -149,7 +149,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
 
   _grid->addWidget(_volume_display, current_row, 1);
   _grid->addWidget(_create_text_label(" dB"), current_row, 2);
-  
+
   current_row++;
 
   // mute state
@@ -161,7 +161,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   connect(_muted_check_box, SIGNAL( toggled(bool) ), this, SLOT( _set_source_mute(bool) ));
 
   _grid->addWidget(_muted_check_box, current_row, 2, Qt::AlignLeft);
- 
+
   current_row++;
 
   // solo state
@@ -173,7 +173,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   //connect(_soloed_check_box, SIGNAL( toggled(bool) ), this, SLOT( _set_source_solo(bool) ));
 
   //_grid->addWidget(_soloed_check_box, current_row, 2, Qt::AlignLeft);
-  
+
   //current_row++;
 
   // source model
@@ -201,7 +201,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _audio_source_display->setFrame(false);
   _audio_source_display->setAlignment(Qt::AlignRight);
   _audio_source_display->setReadOnly(true);
-  
+
   _grid->addWidget(_audio_source_display, current_row, 1, 1, 2);
 
   current_row++;
@@ -247,7 +247,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _create_source_button->setObjectName("item");
   //connect(_less_button, SIGNAL( clicked() ), this, SLOT( _collapse() ));
   //_grid->addWidget(_create_source_button, current_row, 1, 1, 2);
- 
+
   current_row++;
 
 
@@ -269,7 +269,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
 
   // _collapse();
   _expand();
-  
+
 }
 
 QSourceProperties::~QSourceProperties()
@@ -288,26 +288,26 @@ QLabel* QSourceProperties::_create_text_label(const QString& text)
   return buffer;
 }
 
-void QSourceProperties::update_displays(const Source& source, 
+void QSourceProperties::update_displays(const Source& source,
 					const DirectionalPoint& reference)
 {
   // do not update display if dialog is used to create a new sound source
   if ( _create_new_source ) return;
- 
+
   if (!_name_display->hasFocus())
      _name_display->setText( QString::fromStdString( source.name.c_str() ) );
 
   if (!_audio_source_display->hasFocus())
-     _audio_source_display->setText( 
+     _audio_source_display->setText(
                         QString::fromStdString( source.port_name.c_str() ) );
 
-  _coordinates_display->setText(QString().setNum(source.position.x,'f',2) + 
+  _coordinates_display->setText(QString().setNum(source.position.x,'f',2) +
 				", " + QString().setNum(source.position.y,'f',2));
 
   // calculate distance between reference point and source
   const float dist = sqrt(square(source.position.x - reference.position.x) +
 			  square(source.position.y - reference.position.y));
-  
+
   _distance_display->setText(QString().setNum(dist,'f',2));
 
   // calculate angle from which the source is seen
@@ -317,7 +317,7 @@ void QSourceProperties::update_displays(const Source& source,
   ang = std::fmod(ang, 360.0f);
   if (ang > 180.0f) ang -= 360.0f;
   else if (ang <= -180.0f) ang += 360.0f;
-  
+
   _azimuth_display->setText(QString().setNum(ang,'f',2));
   _position_fix_box->setChecked(source.fixed_position);
   // set source model
@@ -413,20 +413,21 @@ void QSourceProperties::_set_doppler(bool flag)
   //emit signal_set_source_property( );
 }
 
-bool QSourceProperties::event(QEvent *e)
-{
-  // catch mouse events
-  if (e->type() == QEvent::MouseButtonDblClick ||
-      e->type() == QEvent::MouseButtonPress ||
-      e->type() == QEvent::MouseButtonRelease ||
-      e->type() == QEvent::MouseMove)
-  {
-    e->accept();
-    return true;
-  }
-  else return false;
+// bool QSourceProperties::event(QEvent *e)
+// {
+//   // catch mouse events
+//   if (e->type() == QEvent::MouseButtonDblClick ||
+//       e->type() == QEvent::MouseButtonPress ||
+//       e->type() == QEvent::MouseButtonRelease ||
+//       e->type() == QEvent::MouseMove)
+//   {
+//     e->accept();
+//     return true;
+//   }
+//   else return false;
+//
+// }
 
-}
 // Settings for Vim (http://www.vim.org/), please do not remove:
 // vim:softtabstop=2:shiftwidth=2:expandtab:textwidth=80:cindent
 // vim:fdm=expr:foldexpr=getline(v\:lnum)=~'/\\*\\*'&&getline(v\:lnum)!~'\\*\\*/'?'a1'\:getline(v\:lnum)=~'\\*\\*/'&&getline(v\:lnum)!~'/\\*\\*'?'s1'\:'='

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -43,7 +43,11 @@ using namespace apf::math;
 //#define ROWHEIGHT 40
 
 QSourceProperties::QSourceProperties(QWidget* parent)
+#ifdef __APPLE__
 : QFrame(parent, Qt::Window | Qt::CustomizeWindowHint),
+#else
+    : QFrame(parent),
+#endif
     _create_new_source(false)
 {
   this->setAutoFillBackground(true);

--- a/src/gui/qsourceproperties.cpp
+++ b/src/gui/qsourceproperties.cpp
@@ -27,7 +27,7 @@
 /// @file
 /// TODO: add description
 
-#include <QtGui/QPalette>
+#include <QtGui/QPalette> 
 #include <QtWidgets/QSizePolicy>
 
 #include "qsourceproperties.h"
@@ -71,13 +71,13 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _name_display->setFrame(false);
   _name_display->setReadOnly(true);
   _name_display->setFocusPolicy(Qt::NoFocus);
-
+  
   _grid->addWidget(_name_display, current_row, 1, 1, 1);
 
   current_row++;
 
   // coordinates
-
+  
   _grid->addWidget(_create_text_label("<font color=\"#888888\">x, y</font>"), current_row, 0);
 
   _coordinates_display = new QLabel();
@@ -88,7 +88,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _grid->addWidget(_create_text_label(" mtrs"), current_row, 2);
 
   current_row++;
-
+  
   // distance
 
   _grid->addWidget(_create_text_label("<font color=\"#888888\">distance</font>"), current_row, 0);
@@ -112,7 +112,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
 
   _grid->addWidget(_azimuth_display, current_row, 1);
   _grid->addWidget(_create_text_label(" degs"), current_row, 2);
-
+  
   current_row++;
 
   // position fix
@@ -124,7 +124,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   connect(_position_fix_box, SIGNAL( toggled(bool) ), this, SLOT( _set_source_position_fixed(bool) ));
 
   _grid->addWidget(_position_fix_box, current_row, 2, Qt::AlignLeft);
-
+ 
   current_row++;
 
   // doppler effect enabled
@@ -136,7 +136,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   //connect(_doppler_box, SIGNAL( toggled(bool) ), this, SLOT( _set_doppler(bool) ));
 
   //_grid->addWidget(_doppler_box, current_row, 2, Qt::AlignLeft);
-
+ 
   //current_row++;
 
   // volume
@@ -149,7 +149,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
 
   _grid->addWidget(_volume_display, current_row, 1);
   _grid->addWidget(_create_text_label(" dB"), current_row, 2);
-
+  
   current_row++;
 
   // mute state
@@ -161,7 +161,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   connect(_muted_check_box, SIGNAL( toggled(bool) ), this, SLOT( _set_source_mute(bool) ));
 
   _grid->addWidget(_muted_check_box, current_row, 2, Qt::AlignLeft);
-
+ 
   current_row++;
 
   // solo state
@@ -173,7 +173,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   //connect(_soloed_check_box, SIGNAL( toggled(bool) ), this, SLOT( _set_source_solo(bool) ));
 
   //_grid->addWidget(_soloed_check_box, current_row, 2, Qt::AlignLeft);
-
+  
   //current_row++;
 
   // source model
@@ -201,7 +201,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _audio_source_display->setFrame(false);
   _audio_source_display->setAlignment(Qt::AlignRight);
   _audio_source_display->setReadOnly(true);
-
+  
   _grid->addWidget(_audio_source_display, current_row, 1, 1, 2);
 
   current_row++;
@@ -247,7 +247,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
   _create_source_button->setObjectName("item");
   //connect(_less_button, SIGNAL( clicked() ), this, SLOT( _collapse() ));
   //_grid->addWidget(_create_source_button, current_row, 1, 1, 2);
-
+ 
   current_row++;
 
 
@@ -269,7 +269,7 @@ QSourceProperties::QSourceProperties(QWidget* parent)
 
   // _collapse();
   _expand();
-
+  
 }
 
 QSourceProperties::~QSourceProperties()
@@ -288,26 +288,26 @@ QLabel* QSourceProperties::_create_text_label(const QString& text)
   return buffer;
 }
 
-void QSourceProperties::update_displays(const Source& source,
+void QSourceProperties::update_displays(const Source& source, 
 					const DirectionalPoint& reference)
 {
   // do not update display if dialog is used to create a new sound source
   if ( _create_new_source ) return;
-
+ 
   if (!_name_display->hasFocus())
      _name_display->setText( QString::fromStdString( source.name.c_str() ) );
 
   if (!_audio_source_display->hasFocus())
-     _audio_source_display->setText(
+     _audio_source_display->setText( 
                         QString::fromStdString( source.port_name.c_str() ) );
 
-  _coordinates_display->setText(QString().setNum(source.position.x,'f',2) +
+  _coordinates_display->setText(QString().setNum(source.position.x,'f',2) + 
 				", " + QString().setNum(source.position.y,'f',2));
 
   // calculate distance between reference point and source
   const float dist = sqrt(square(source.position.x - reference.position.x) +
 			  square(source.position.y - reference.position.y));
-
+  
   _distance_display->setText(QString().setNum(dist,'f',2));
 
   // calculate angle from which the source is seen
@@ -317,7 +317,7 @@ void QSourceProperties::update_displays(const Source& source,
   ang = std::fmod(ang, 360.0f);
   if (ang > 180.0f) ang -= 360.0f;
   else if (ang <= -180.0f) ang += 360.0f;
-
+  
   _azimuth_display->setText(QString().setNum(ang,'f',2));
   _position_fix_box->setChecked(source.fixed_position);
   // set source model
@@ -413,21 +413,20 @@ void QSourceProperties::_set_doppler(bool flag)
   //emit signal_set_source_property( );
 }
 
-// bool QSourceProperties::event(QEvent *e)
-// {
-//   // catch mouse events
-//   if (e->type() == QEvent::MouseButtonDblClick ||
-//       e->type() == QEvent::MouseButtonPress ||
-//       e->type() == QEvent::MouseButtonRelease ||
-//       e->type() == QEvent::MouseMove)
-//   {
-//     e->accept();
-//     return true;
-//   }
-//   else return false;
-//
-// }
+bool QSourceProperties::event(QEvent *e)
+{
+  // catch mouse events
+  if (e->type() == QEvent::MouseButtonDblClick ||
+      e->type() == QEvent::MouseButtonPress ||
+      e->type() == QEvent::MouseButtonRelease ||
+      e->type() == QEvent::MouseMove)
+  {
+    e->accept();
+    return true;
+  }
+  else return false;
 
+}
 // Settings for Vim (http://www.vim.org/), please do not remove:
 // vim:softtabstop=2:shiftwidth=2:expandtab:textwidth=80:cindent
 // vim:fdm=expr:foldexpr=getline(v\:lnum)=~'/\\*\\*'&&getline(v\:lnum)!~'\\*\\*/'?'a1'\:getline(v\:lnum)=~'\\*\\*/'&&getline(v\:lnum)!~'/\\*\\*'?'s1'\:'='

--- a/src/gui/qsourceproperties.h
+++ b/src/gui/qsourceproperties.h
@@ -30,13 +30,14 @@
 #ifndef SSR_QSOURCEPROPERTIES_H
 #define SSR_QSOURCEPROPERTIES_H
 
-#include <QFrame>
-#include <QGridLayout>
-#include <QCheckBox>
-#include <QMouseEvent>
-#include <QLineEdit>
-#include <QComboBox>
-#include <QRadioButton>
+
+#include <QtGui/QMouseEvent>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QFrame>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QRadioButton>
 
 #include "qclicktextlabel.h"
 #include "source.h"

--- a/src/gui/qsourceproperties.h
+++ b/src/gui/qsourceproperties.h
@@ -82,7 +82,6 @@ class QSourceProperties : public QFrame
     bool _create_new_source;
 
     virtual void mousePressEvent(QMouseEvent *event);
-    virtual bool event(QEvent *e);
 
   private slots:
       void _set_source_mute(bool flag);

--- a/src/gui/qsourceproperties.h
+++ b/src/gui/qsourceproperties.h
@@ -51,7 +51,7 @@ class QSourceProperties : public QFrame
     QSourceProperties(QWidget* parent = 0);
     ~QSourceProperties();
 
-    void update_displays(const Source& source,
+    void update_displays(const Source& source, 
 			 const DirectionalPoint& reference);
 
   private:
@@ -78,11 +78,11 @@ class QSourceProperties : public QFrame
     QClickTextLabel* _close_button;
 
     QLabel* _create_text_label(const QString& text = QString());
-
+   
     bool _create_new_source;
 
     virtual void mousePressEvent(QMouseEvent *event);
-    //virtual bool event(QEvent *e);
+    virtual bool event(QEvent *e);
 
   private slots:
       void _set_source_mute(bool flag);

--- a/src/gui/qsourceproperties.h
+++ b/src/gui/qsourceproperties.h
@@ -51,7 +51,7 @@ class QSourceProperties : public QFrame
     QSourceProperties(QWidget* parent = 0);
     ~QSourceProperties();
 
-    void update_displays(const Source& source, 
+    void update_displays(const Source& source,
 			 const DirectionalPoint& reference);
 
   private:
@@ -78,11 +78,11 @@ class QSourceProperties : public QFrame
     QClickTextLabel* _close_button;
 
     QLabel* _create_text_label(const QString& text = QString());
-   
+
     bool _create_new_source;
 
     virtual void mousePressEvent(QMouseEvent *event);
-    virtual bool event(QEvent *e);
+    //virtual bool event(QEvent *e);
 
   private slots:
       void _set_source_mute(bool flag);

--- a/src/gui/qssrtimeline.cpp
+++ b/src/gui/qssrtimeline.cpp
@@ -27,10 +27,11 @@
 /// @file
 /// TODO: add description
 
-#include <QPainter>
-#include <QTimer>
 #include <algorithm>
 #include <cmath>
+
+#include <QtCore/QTimer>
+#include <QtGui/QPainter>
 
 #include "qssrtimeline.h"
 #include "ssr_global.h"

--- a/src/gui/qssrtimeline.cpp
+++ b/src/gui/qssrtimeline.cpp
@@ -51,7 +51,7 @@ QSSRTimeLine::QSSRTimeLine(QWidget* parent, unsigned int update_interval)
 {
   (void)update_interval;
 
-   _time_edit = new  QTimeEdit(this);
+   _time_edit = new  QSSRTimeEdit(this);
    connect(_time_edit, SIGNAL(returnPressed()), this, SLOT(_interpret_time_edit()));
    _time_edit->setVisible(false);
 

--- a/src/gui/qssrtimeline.h
+++ b/src/gui/qssrtimeline.h
@@ -30,11 +30,11 @@
 #ifndef SSR_QTIMELINE_H
 #define SSR_QTIMELINE_H
 
-#include <QLabel>
-#include <QLineEdit>
-#include <QPoint>
-#include <QMouseEvent>
-#include <QPaintEvent>
+#include <QtCore/QPoint>
+#include <QtGui/QMouseEvent>
+#include <QtGui/QPaintEvent>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
 
 #include "qtimeedit.h"
 

--- a/src/gui/qssrtimeline.h
+++ b/src/gui/qssrtimeline.h
@@ -57,7 +57,7 @@ class QSSRTimeLine : public QLabel
     float        _progress_at_mouse_click;
     QString      _previous_time;
 
-    QTimeEdit*   _time_edit;
+    QSSRTimeEdit*   _time_edit;
 
   protected:
     virtual void mousePressEvent(QMouseEvent *event);

--- a/src/gui/qtimeedit.cpp
+++ b/src/gui/qtimeedit.cpp
@@ -30,7 +30,7 @@
 #include "qtimeedit.h"
 //#include "ssr_global.h"
 
-QTimeEdit::QTimeEdit(QWidget* parent) : QLineEdit(parent)
+QSSRTimeEdit::QSSRTimeEdit(QWidget* parent) : QLineEdit(parent)
 {
   QString qt_style_sheet = "* { background-color: white; \n"
                                "border-radius: 0;       \n"
@@ -40,7 +40,9 @@ QTimeEdit::QTimeEdit(QWidget* parent) : QLineEdit(parent)
   this->setStyleSheet(qt_style_sheet);
 }
 
-void QTimeEdit::keyPressEvent(QKeyEvent *event)
+QSSRTimeEdit::~QSSRTimeEdit(){}
+
+void QSSRTimeEdit::keyPressEvent(QKeyEvent *event)
 {
   QLineEdit::keyPressEvent(event);
 

--- a/src/gui/qtimeedit.h
+++ b/src/gui/qtimeedit.h
@@ -30,8 +30,8 @@
 #ifndef SSR_QTIMEEDIT_H
 #define SSR_QTIMEEDIT_H
 
-#include <QLineEdit>
-#include <QKeyEvent>
+#include <QtGui/QKeyEvent>
+#include <QtWidgets/QLineEdit>
 
 /// for QSSRTimeLine 
 class QTimeEdit : public QLineEdit

--- a/src/gui/qtimeedit.h
+++ b/src/gui/qtimeedit.h
@@ -34,12 +34,15 @@
 #include <QtWidgets/QLineEdit>
 
 /// for QSSRTimeLine 
-class QTimeEdit : public QLineEdit
+
+class QSSRTimeEdit : public QLineEdit
 {
   Q_OBJECT
 
   public:
-    QTimeEdit( QWidget* parent = 0 );
+    explicit QSSRTimeEdit(QWidget *parent = Q_NULLPTR);
+    ~QSSRTimeEdit();
+
 
   protected:
     virtual void keyPressEvent(QKeyEvent *event);

--- a/src/gui/quserinterface.cpp
+++ b/src/gui/quserinterface.cpp
@@ -26,20 +26,20 @@
 
 /// @file
 /// TODO: add description
-
-#include <QResizeEvent>
-#include <QMouseEvent>
-#include <QFileDialog>
-#include <QMessageBox>
-#include <QHBoxLayout>
-#include <QVBoxLayout>
-#include <QMenu>
-#include <QTimer>
-#include <QApplication>
-#include <QDesktopWidget>
 #include <string>
 #include <fstream>
 #include <cmath>
+
+#include <QtCore/QTimer>
+#include <QtGui/QMouseEvent>
+#include <QtGui/QResizeEvent>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QDesktopWidget>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QVBoxLayout>
 
 #include "quserinterface.h"
 #include "apf/math.h"
@@ -647,7 +647,7 @@ void ssr::QUserInterface::_load_scene(const QString& path_to_scene)
     }
   }
 
-  _controller.load_scene(std::string(path_to_scene.toAscii()));
+  _controller.load_scene(std::string(path_to_scene.toLatin1()));
 
   // clear mouse cursor
   setCursor(Qt::ArrowCursor);

--- a/src/gui/quserinterface.cpp
+++ b/src/gui/quserinterface.cpp
@@ -647,7 +647,7 @@ void ssr::QUserInterface::_load_scene(const QString& path_to_scene)
     }
   }
 
-  _controller.load_scene(std::string(path_to_scene.toLatin1()));
+  _controller.load_scene(std::string(path_to_scene.toUtf8()));
 
   // clear mouse cursor
   setCursor(Qt::ArrowCursor);

--- a/src/gui/quserinterface.cpp
+++ b/src/gui/quserinterface.cpp
@@ -113,7 +113,7 @@ ssr::QUserInterface::QUserInterface(Publisher& controller, const Scene& scene
 
   // set default size
   setGeometry(200, 100, 900, 800);
-  
+
 #ifdef ENABLE_FLOATING_CONTROL_PANEL
   // TODO: use screen size for initial window positions
   //QRect screenSize = QApplication::desktop()->screenGeometry();
@@ -134,7 +134,7 @@ ssr::QUserInterface::QUserInterface(Publisher& controller, const Scene& scene
   connect(_source_properties, SIGNAL(signal_set_source_position_fixed(bool)), this, SLOT(_set_source_position_fixed(bool)));
   connect(_source_properties, SIGNAL(signal_set_source_model(int)), this, SLOT(_set_source_model(int)));
   _source_properties->hide();
-  
+
   // set window icon
   QString path_to_image( _path_to_gui_images.c_str() ) ;
   setWindowIcon(QIcon(QPixmap(path_to_image.append("/ssr_logo_large.png"))));
@@ -264,7 +264,7 @@ ssr::QUserInterface::~QUserInterface()
   // clear memory if scene button list has been in use
   if (!_scene_button_list.empty())
   {
-    for (scene_button_list_t::iterator i = _scene_button_list.begin(); 
+    for (scene_button_list_t::iterator i = _scene_button_list.begin();
 	 i != _scene_button_list.end(); i++)
     {
       delete *i;
@@ -289,7 +289,7 @@ void ssr::QUserInterface::_transport_locate(float time)
   {
     _controller.transport_locate(time);
   }
-  else 
+  else
   {
     _skip_back();
   }
@@ -303,14 +303,14 @@ void ssr::QUserInterface::_solo_selected_sources()
 {
   _soloed_sources.clear();
 
-  for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
+  for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
        i != _selected_sources_map.end(); i++)
   {
     _soloed_sources.insert(i->second);
 
     // make sure it's not muted
     _controller.set_source_mute(i->second, false);
-   
+
   } // for
 
   // get sources
@@ -318,7 +318,7 @@ void ssr::QUserInterface::_solo_selected_sources()
   _scene.get_sources(source_buffer_list);
 
   // mute other sources
-  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin(); 
+  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin();
        i != source_buffer_list.end(); i++)
   {
     // if source is not soloed
@@ -335,7 +335,7 @@ void ssr::QUserInterface::_solo_selected_sources()
 /// this function is not so useful
 void ssr::QUserInterface::_unsolo_selected_sources()
 {
-  for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
+  for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
        i != _selected_sources_map.end(); i++)
   {
     _soloed_sources.erase(i->second);
@@ -349,11 +349,11 @@ void ssr::QUserInterface::_unsolo_selected_sources()
   // if other sources are soloed
   else
   {
-    for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
+    for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
 	 i != _selected_sources_map.end(); i++)
     {
       // then mute the unsoloed sources
-      _controller.set_source_mute(i->second, true); 
+      _controller.set_source_mute(i->second, true);
     } // for
   }
 
@@ -361,15 +361,15 @@ void ssr::QUserInterface::_unsolo_selected_sources()
 
 void ssr::QUserInterface::_toggle_solo_state_of_selected_sources()
 {
-  for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
+  for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
        i != _selected_sources_map.end(); i++)
   {
     if (_soloed_sources.find(i->second) == _soloed_sources.end())
     {
       // solo source
-      _soloed_sources.insert(i->second); 
+      _soloed_sources.insert(i->second);
     }
-    else 
+    else
     {
       // unsolo source
       _soloed_sources.erase(i->second);
@@ -380,15 +380,15 @@ void ssr::QUserInterface::_toggle_solo_state_of_selected_sources()
   source_buffer_list_t source_buffer_list;
   _scene.get_sources(source_buffer_list);
 
-  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin(); 
+  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin();
        i != source_buffer_list.end(); i++)
   {
     if (_soloed_sources.find(i->id) == _soloed_sources.end())
     {
-      // mute 
+      // mute
       _controller.set_source_mute(i->id, true);
     }
-    else 
+    else
     {
       // unmute
       _controller.set_source_mute(i->id, false);
@@ -404,7 +404,7 @@ void ssr::QUserInterface::_unsolo_all_sources()
   source_buffer_list_t source_buffer_list;
   _scene.get_sources(source_buffer_list);
 
-  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin(); 
+  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin();
        i != source_buffer_list.end(); i++)
   {
     _controller.set_source_mute(i->id, false);
@@ -534,7 +534,7 @@ void ssr::QUserInterface::_create_scene_menu(const std::string& path_to_scene_me
 
       // Add button to list
       _scene_button_list.push_back(button_buffer);
-      
+
       // increment _scene counter
       no_of_scenes++;
     } // if
@@ -585,22 +585,22 @@ void ssr::QUserInterface::_change_volume_of_selected_sources(float d_volume)
     current_gain = std::max(current_gain, dB2linear(MINVOLUME));
 
     _controller.set_source_gain(i->second, current_gain);
-   
+
   } // for
 }
 
 /// Opens a save-file-as dialog.
 void ssr::QUserInterface::_save_file_as()
 {
-  QString file_name = QFileDialog::getSaveFileName(this, 
+  QString file_name = QFileDialog::getSaveFileName(this,
                         "Save scene in ASDF", ".", "ASDF files (*.asd)");
 
   // if aborted
-  if ( file_name.isEmpty() ) 
-  { 
+  if ( file_name.isEmpty() )
+  {
     VERBOSE("Scene not saved.");
-  } 
-  else 
+  }
+  else
   {
     // convert to std::string
     std::string file_name_std = file_name.toStdString();
@@ -688,9 +688,9 @@ void ssr::QUserInterface::_update_screen()
     {
       // move the dialog to the desired position
       _update_source_properties_position();
-      
+
       // update displays of source properties dialog
-      _source_properties->update_displays(_scene.get_source(_id_of_last_clicked_source), 
+      _source_properties->update_displays(_scene.get_source(_id_of_last_clicked_source),
 					  _scene.get_reference());
     } // if
 
@@ -776,10 +776,10 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
   const int _time_line_position_x = DEFAULTFRAMELEFT+FILEMENUWIDTH+
   4*(BETWEENBUTTONSPACE+BUTTONWIDTH)+
   BETWEENLABELSPACE - 12; // the 12 is due to LEFTMARGIN in qssrtimeline.cpp
-  
+
   const int _zoom_label_position_x = newWidth - DEFAULTFRAMERIGHT + 3 -
   FILEMENUWIDTH - 2*BUTTONWIDTH - 2*BETWEENLABELSPACE;
-  
+
   // if there is space then show the _time_line
   if (width()-DEFAULTFRAMERIGHT-FILEMENUWIDTH-150 > _time_line_position_x + 30)
   {
@@ -788,13 +788,13 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
     _time_line->show();
   }
   else _time_line->hide();
-  
+
   // if there is space then show the _zoom_label
   if (_zoom_label_position_x > _time_line_position_x - BETWEENLABELSPACE)
   {
     _zoom_label->setGeometry(_zoom_label_position_x, 30, BUTTONWIDTH, 15);
     _zoom_label_text_tag->setGeometry(_zoom_label_position_x, 15, BUTTONWIDTH, 15);
-    
+
     _zoom_label->show();
     _zoom_label_text_tag->show();
   }
@@ -803,7 +803,7 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
     _zoom_label->hide();
     _zoom_label_text_tag->hide();
   }
-  
+
   // if there is space then show the _cpu_label
   if (_zoom_label_position_x > _time_line_position_x - 2*BETWEENLABELSPACE - BUTTONWIDTH)
   {
@@ -811,22 +811,22 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
                             30, BUTTONWIDTH, 15);
     _cpu_label_text_tag->setGeometry(_zoom_label_position_x+BUTTONWIDTH+
                                      BETWEENLABELSPACE, 15, BUTTONWIDTH, 15 );
-    
+
     _cpu_label->show();
     _cpu_label_text_tag->show();
-    
+
   }
   else
   {
     _cpu_label->hide();
     _cpu_label_text_tag->hide();
   }
-  
+
   _volume_slider->setGeometry(newWidth - DEFAULTFRAMERIGHT - FILEMENUWIDTH + 3, 30, FILEMENUWIDTH, 25);
   _volume_slider_text_tag->setGeometry(newWidth - DEFAULTFRAMERIGHT - FILEMENUWIDTH + 3, 15, FILEMENUWIDTH, 15 );
-  
+
   int no_of_scenes = 0;
-  
+
   // check which scene buttons are visible
   if (!_scene_button_list.empty())
   {
@@ -839,11 +839,11 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
         (*i)->show();
       }
       else (*i)->hide();
-      
+
       no_of_scenes++;
     }
   }
-}  
+}
 
 /** Handles Qt mouse press events.
  * @param event Qt mouse event.
@@ -851,7 +851,7 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
 void ssr::QUserInterface::mousePressEvent(QMouseEvent *event)
 {
   ssr::id_t _id_of_lastlast_clicked_source = _id_of_last_clicked_source;
-  
+
   event->accept();
 
   _volume_slider_selected = false;
@@ -892,7 +892,7 @@ void ssr::QUserInterface::mousePressEvent(QMouseEvent *event)
   {
     // hide source properties dialog
     _source_properties->hide();
-    
+
     // no source was clicked
     if (event->button() == Qt::LeftButton) _deselect_all_sources();
     return;
@@ -975,7 +975,7 @@ void ssr::QUserInterface::mouseMoveEvent(QMouseEvent *event)
     // move all selected sources
     for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); i != _selected_sources_map.end(); i++)
     {
-      // rotate complex sources by the appropriate angle 
+      // rotate complex sources by the appropriate angle
       if (_scene.get_source_model(i->second) == Source::directional ||
                _scene.get_source_model(i->second) == Source::extended)
       {
@@ -1144,11 +1144,7 @@ void ssr::QUserInterface::_update_source_properties_position()
   _get_pixel_pos(source_position->x, source_position->y,
 		 0,&x, &y);
 
-#ifdef __APPLE__
   _source_properties->move(QPoint(this->x() + x + 100, this->y() + y));
-#else
-  _source_properties->move(QPoint(x + 100, y));
-#endif
 
 }
 
@@ -1172,8 +1168,8 @@ void ssr::QUserInterface::mouseDoubleClickEvent(QMouseEvent *event)
     // restore zoom
     _set_zoom(100);
   }
-  else 
-  { 
+  else
+  {
     // double click on source
     if (_source_properties->isVisible())
     {
@@ -1245,23 +1241,23 @@ void ssr::QUserInterface::keyPressEvent(QKeyEvent *event)
   case Qt::Key_A: if (event->modifiers() == Qt::ControlModifier) _select_all_sources(); break;
   case Qt::Key_F: _toggle_fixation_state_of_selected_sources(); break;
   case Qt::Key_M: _toggle_mute_state_of_selected_sources(); break;
-  case Qt::Key_P: _toggle_source_models(); break;  
+  case Qt::Key_P: _toggle_source_models(); break;
   case Qt::Key_R: _controller.set_auto_rotation(!_scene.get_auto_rotation()); break;
 
-  case Qt::Key_S: if ( event->modifiers() == Qt::ControlModifier ) 
+  case Qt::Key_S: if ( event->modifiers() == Qt::ControlModifier )
                   {
                     _save_file_as();
                   }
-                  else if (_selected_sources_map.empty()) 
+                  else if (_selected_sources_map.empty())
                   {
                     _unsolo_all_sources();
                   }
-		  else _solo_selected_sources(); 
+		  else _solo_selected_sources();
                   break;
 
-  case Qt::Key_T: if ( event->modifiers() == Qt::ControlModifier ) 
+  case Qt::Key_T: if ( event->modifiers() == Qt::ControlModifier )
                   {
-		    _time_line->show_time_edit(); 
+		    _time_line->show_time_edit();
                   }
                   break;
 
@@ -1278,21 +1274,21 @@ void ssr::QUserInterface::keyPressEvent(QKeyEvent *event)
 
     // miscellaneous actions
   case Qt::Key_Plus: if (_selected_sources_map.empty())
-		     { 
+		     {
 		       // change master level
 		       _set_master_volume(linear2dB(_scene.get_master_volume() + 0.00001f) + 1.0f); // min -100dB
 		     }
                      // change selected sources level
 		     else _change_volume_of_selected_sources(1.0f);
-                     break;   
+                     break;
   case Qt::Key_Minus: if (_selected_sources_map.empty())
-		     { 
+		     {
 		       // change master level
 		       _set_master_volume(linear2dB(_scene.get_master_volume() + 0.00001f) - 1.0f); // min -100dB
 		     }
                      // change selected sources level
 		     else _change_volume_of_selected_sources(-1.0f);
-                     break; 
+                     break;
   case Qt::Key_Return: {_controller.calibrate_client(); break; }
   case Qt::Key_Control: {_ctrl_pressed = true; break; }
   case Qt::Key_Alt: {_alt_pressed = true; break; }
@@ -1377,7 +1373,7 @@ void ssr::QUserInterface::_show_about_window()
 
   // text_label.setGeometry(0, 261, 350, 370);
   text_label.setText(about_string.c_str());
-  text_label.setIndent(20); 
+  text_label.setIndent(20);
   text_label.setAlignment(Qt::AlignTop);
   text_label.adjustSize();
 
@@ -1393,7 +1389,7 @@ void ssr::QUserInterface::_show_about_window()
 
   connect(&ssr_logo, SIGNAL(clicked()), &about_window, SLOT(close()));
   connect(&text_label, SIGNAL(clicked()), &about_window, SLOT(close()));
- 
+
   about_window.exec();
 }
 
@@ -1429,12 +1425,12 @@ void ssr::QUserInterface::_toggle_source_models()
     }
     else if (_scene.get_source_model(i->second) == Source::point)
     {
-      _controller.set_source_model(i->second, Source::plane);      
+      _controller.set_source_model(i->second, Source::plane);
     } // if
   } // for
 }
 
-/** Sets the position fixed state of the currently active mouse.  
+/** Sets the position fixed state of the currently active mouse.
  * @param flag \a true or \a false
  */
 void ssr::QUserInterface::_set_source_position_fixed(const bool flag)
@@ -1442,13 +1438,13 @@ void ssr::QUserInterface::_set_source_position_fixed(const bool flag)
   _controller.set_source_position_fixed(_id_of_last_clicked_source, flag);
 }
 
-/** Sets the position fixed state of the currently active mouse.  
- * @param index \a 0="plane wave" \a 1="point source" 
+/** Sets the position fixed state of the currently active mouse.
+ * @param index \a 0="plane wave" \a 1="point source"
  */
 void ssr::QUserInterface::_set_source_model(const int index)
 {
   Source::model_t model = Source::unknown;
-  
+
   switch(index){
     case 0:
       model = Source::plane;

--- a/src/gui/quserinterface.cpp
+++ b/src/gui/quserinterface.cpp
@@ -113,7 +113,7 @@ ssr::QUserInterface::QUserInterface(Publisher& controller, const Scene& scene
 
   // set default size
   setGeometry(200, 100, 900, 800);
-
+  
 #ifdef ENABLE_FLOATING_CONTROL_PANEL
   // TODO: use screen size for initial window positions
   //QRect screenSize = QApplication::desktop()->screenGeometry();
@@ -134,7 +134,7 @@ ssr::QUserInterface::QUserInterface(Publisher& controller, const Scene& scene
   connect(_source_properties, SIGNAL(signal_set_source_position_fixed(bool)), this, SLOT(_set_source_position_fixed(bool)));
   connect(_source_properties, SIGNAL(signal_set_source_model(int)), this, SLOT(_set_source_model(int)));
   _source_properties->hide();
-
+  
   // set window icon
   QString path_to_image( _path_to_gui_images.c_str() ) ;
   setWindowIcon(QIcon(QPixmap(path_to_image.append("/ssr_logo_large.png"))));
@@ -264,7 +264,7 @@ ssr::QUserInterface::~QUserInterface()
   // clear memory if scene button list has been in use
   if (!_scene_button_list.empty())
   {
-    for (scene_button_list_t::iterator i = _scene_button_list.begin();
+    for (scene_button_list_t::iterator i = _scene_button_list.begin(); 
 	 i != _scene_button_list.end(); i++)
     {
       delete *i;
@@ -289,7 +289,7 @@ void ssr::QUserInterface::_transport_locate(float time)
   {
     _controller.transport_locate(time);
   }
-  else
+  else 
   {
     _skip_back();
   }
@@ -303,14 +303,14 @@ void ssr::QUserInterface::_solo_selected_sources()
 {
   _soloed_sources.clear();
 
-  for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
+  for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
        i != _selected_sources_map.end(); i++)
   {
     _soloed_sources.insert(i->second);
 
     // make sure it's not muted
     _controller.set_source_mute(i->second, false);
-
+   
   } // for
 
   // get sources
@@ -318,7 +318,7 @@ void ssr::QUserInterface::_solo_selected_sources()
   _scene.get_sources(source_buffer_list);
 
   // mute other sources
-  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin();
+  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin(); 
        i != source_buffer_list.end(); i++)
   {
     // if source is not soloed
@@ -335,7 +335,7 @@ void ssr::QUserInterface::_solo_selected_sources()
 /// this function is not so useful
 void ssr::QUserInterface::_unsolo_selected_sources()
 {
-  for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
+  for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
        i != _selected_sources_map.end(); i++)
   {
     _soloed_sources.erase(i->second);
@@ -349,11 +349,11 @@ void ssr::QUserInterface::_unsolo_selected_sources()
   // if other sources are soloed
   else
   {
-    for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
+    for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
 	 i != _selected_sources_map.end(); i++)
     {
       // then mute the unsoloed sources
-      _controller.set_source_mute(i->second, true);
+      _controller.set_source_mute(i->second, true); 
     } // for
   }
 
@@ -361,15 +361,15 @@ void ssr::QUserInterface::_unsolo_selected_sources()
 
 void ssr::QUserInterface::_toggle_solo_state_of_selected_sources()
 {
-  for (selected_sources_map_t::iterator i = _selected_sources_map.begin();
+  for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); 
        i != _selected_sources_map.end(); i++)
   {
     if (_soloed_sources.find(i->second) == _soloed_sources.end())
     {
       // solo source
-      _soloed_sources.insert(i->second);
+      _soloed_sources.insert(i->second); 
     }
-    else
+    else 
     {
       // unsolo source
       _soloed_sources.erase(i->second);
@@ -380,15 +380,15 @@ void ssr::QUserInterface::_toggle_solo_state_of_selected_sources()
   source_buffer_list_t source_buffer_list;
   _scene.get_sources(source_buffer_list);
 
-  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin();
+  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin(); 
        i != source_buffer_list.end(); i++)
   {
     if (_soloed_sources.find(i->id) == _soloed_sources.end())
     {
-      // mute
+      // mute 
       _controller.set_source_mute(i->id, true);
     }
-    else
+    else 
     {
       // unmute
       _controller.set_source_mute(i->id, false);
@@ -404,7 +404,7 @@ void ssr::QUserInterface::_unsolo_all_sources()
   source_buffer_list_t source_buffer_list;
   _scene.get_sources(source_buffer_list);
 
-  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin();
+  for (source_buffer_list_t::const_iterator i = source_buffer_list.begin(); 
        i != source_buffer_list.end(); i++)
   {
     _controller.set_source_mute(i->id, false);
@@ -534,7 +534,7 @@ void ssr::QUserInterface::_create_scene_menu(const std::string& path_to_scene_me
 
       // Add button to list
       _scene_button_list.push_back(button_buffer);
-
+      
       // increment _scene counter
       no_of_scenes++;
     } // if
@@ -585,22 +585,22 @@ void ssr::QUserInterface::_change_volume_of_selected_sources(float d_volume)
     current_gain = std::max(current_gain, dB2linear(MINVOLUME));
 
     _controller.set_source_gain(i->second, current_gain);
-
+   
   } // for
 }
 
 /// Opens a save-file-as dialog.
 void ssr::QUserInterface::_save_file_as()
 {
-  QString file_name = QFileDialog::getSaveFileName(this,
+  QString file_name = QFileDialog::getSaveFileName(this, 
                         "Save scene in ASDF", ".", "ASDF files (*.asd)");
 
   // if aborted
-  if ( file_name.isEmpty() )
-  {
+  if ( file_name.isEmpty() ) 
+  { 
     VERBOSE("Scene not saved.");
-  }
-  else
+  } 
+  else 
   {
     // convert to std::string
     std::string file_name_std = file_name.toStdString();
@@ -688,9 +688,9 @@ void ssr::QUserInterface::_update_screen()
     {
       // move the dialog to the desired position
       _update_source_properties_position();
-
+      
       // update displays of source properties dialog
-      _source_properties->update_displays(_scene.get_source(_id_of_last_clicked_source),
+      _source_properties->update_displays(_scene.get_source(_id_of_last_clicked_source), 
 					  _scene.get_reference());
     } // if
 
@@ -776,10 +776,10 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
   const int _time_line_position_x = DEFAULTFRAMELEFT+FILEMENUWIDTH+
   4*(BETWEENBUTTONSPACE+BUTTONWIDTH)+
   BETWEENLABELSPACE - 12; // the 12 is due to LEFTMARGIN in qssrtimeline.cpp
-
+  
   const int _zoom_label_position_x = newWidth - DEFAULTFRAMERIGHT + 3 -
   FILEMENUWIDTH - 2*BUTTONWIDTH - 2*BETWEENLABELSPACE;
-
+  
   // if there is space then show the _time_line
   if (width()-DEFAULTFRAMERIGHT-FILEMENUWIDTH-150 > _time_line_position_x + 30)
   {
@@ -788,13 +788,13 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
     _time_line->show();
   }
   else _time_line->hide();
-
+  
   // if there is space then show the _zoom_label
   if (_zoom_label_position_x > _time_line_position_x - BETWEENLABELSPACE)
   {
     _zoom_label->setGeometry(_zoom_label_position_x, 30, BUTTONWIDTH, 15);
     _zoom_label_text_tag->setGeometry(_zoom_label_position_x, 15, BUTTONWIDTH, 15);
-
+    
     _zoom_label->show();
     _zoom_label_text_tag->show();
   }
@@ -803,7 +803,7 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
     _zoom_label->hide();
     _zoom_label_text_tag->hide();
   }
-
+  
   // if there is space then show the _cpu_label
   if (_zoom_label_position_x > _time_line_position_x - 2*BETWEENLABELSPACE - BUTTONWIDTH)
   {
@@ -811,22 +811,22 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
                             30, BUTTONWIDTH, 15);
     _cpu_label_text_tag->setGeometry(_zoom_label_position_x+BUTTONWIDTH+
                                      BETWEENLABELSPACE, 15, BUTTONWIDTH, 15 );
-
+    
     _cpu_label->show();
     _cpu_label_text_tag->show();
-
+    
   }
   else
   {
     _cpu_label->hide();
     _cpu_label_text_tag->hide();
   }
-
+  
   _volume_slider->setGeometry(newWidth - DEFAULTFRAMERIGHT - FILEMENUWIDTH + 3, 30, FILEMENUWIDTH, 25);
   _volume_slider_text_tag->setGeometry(newWidth - DEFAULTFRAMERIGHT - FILEMENUWIDTH + 3, 15, FILEMENUWIDTH, 15 );
-
+  
   int no_of_scenes = 0;
-
+  
   // check which scene buttons are visible
   if (!_scene_button_list.empty())
   {
@@ -839,11 +839,11 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
         (*i)->show();
       }
       else (*i)->hide();
-
+      
       no_of_scenes++;
     }
   }
-}
+}  
 
 /** Handles Qt mouse press events.
  * @param event Qt mouse event.
@@ -851,7 +851,7 @@ void ssr::QUserInterface::_resizeControls(int newWidth)
 void ssr::QUserInterface::mousePressEvent(QMouseEvent *event)
 {
   ssr::id_t _id_of_lastlast_clicked_source = _id_of_last_clicked_source;
-
+  
   event->accept();
 
   _volume_slider_selected = false;
@@ -892,7 +892,7 @@ void ssr::QUserInterface::mousePressEvent(QMouseEvent *event)
   {
     // hide source properties dialog
     _source_properties->hide();
-
+    
     // no source was clicked
     if (event->button() == Qt::LeftButton) _deselect_all_sources();
     return;
@@ -975,7 +975,7 @@ void ssr::QUserInterface::mouseMoveEvent(QMouseEvent *event)
     // move all selected sources
     for (selected_sources_map_t::iterator i = _selected_sources_map.begin(); i != _selected_sources_map.end(); i++)
     {
-      // rotate complex sources by the appropriate angle
+      // rotate complex sources by the appropriate angle 
       if (_scene.get_source_model(i->second) == Source::directional ||
                _scene.get_source_model(i->second) == Source::extended)
       {
@@ -1144,7 +1144,11 @@ void ssr::QUserInterface::_update_source_properties_position()
   _get_pixel_pos(source_position->x, source_position->y,
 		 0,&x, &y);
 
+#ifdef __APPLE__
   _source_properties->move(QPoint(this->x() + x + 100, this->y() + y));
+#else
+  _source_properties->move(QPoint(x + 100, y));
+#endif
 
 }
 
@@ -1168,8 +1172,8 @@ void ssr::QUserInterface::mouseDoubleClickEvent(QMouseEvent *event)
     // restore zoom
     _set_zoom(100);
   }
-  else
-  {
+  else 
+  { 
     // double click on source
     if (_source_properties->isVisible())
     {
@@ -1241,23 +1245,23 @@ void ssr::QUserInterface::keyPressEvent(QKeyEvent *event)
   case Qt::Key_A: if (event->modifiers() == Qt::ControlModifier) _select_all_sources(); break;
   case Qt::Key_F: _toggle_fixation_state_of_selected_sources(); break;
   case Qt::Key_M: _toggle_mute_state_of_selected_sources(); break;
-  case Qt::Key_P: _toggle_source_models(); break;
+  case Qt::Key_P: _toggle_source_models(); break;  
   case Qt::Key_R: _controller.set_auto_rotation(!_scene.get_auto_rotation()); break;
 
-  case Qt::Key_S: if ( event->modifiers() == Qt::ControlModifier )
+  case Qt::Key_S: if ( event->modifiers() == Qt::ControlModifier ) 
                   {
                     _save_file_as();
                   }
-                  else if (_selected_sources_map.empty())
+                  else if (_selected_sources_map.empty()) 
                   {
                     _unsolo_all_sources();
                   }
-		  else _solo_selected_sources();
+		  else _solo_selected_sources(); 
                   break;
 
-  case Qt::Key_T: if ( event->modifiers() == Qt::ControlModifier )
+  case Qt::Key_T: if ( event->modifiers() == Qt::ControlModifier ) 
                   {
-		    _time_line->show_time_edit();
+		    _time_line->show_time_edit(); 
                   }
                   break;
 
@@ -1274,21 +1278,21 @@ void ssr::QUserInterface::keyPressEvent(QKeyEvent *event)
 
     // miscellaneous actions
   case Qt::Key_Plus: if (_selected_sources_map.empty())
-		     {
+		     { 
 		       // change master level
 		       _set_master_volume(linear2dB(_scene.get_master_volume() + 0.00001f) + 1.0f); // min -100dB
 		     }
                      // change selected sources level
 		     else _change_volume_of_selected_sources(1.0f);
-                     break;
+                     break;   
   case Qt::Key_Minus: if (_selected_sources_map.empty())
-		     {
+		     { 
 		       // change master level
 		       _set_master_volume(linear2dB(_scene.get_master_volume() + 0.00001f) - 1.0f); // min -100dB
 		     }
                      // change selected sources level
 		     else _change_volume_of_selected_sources(-1.0f);
-                     break;
+                     break; 
   case Qt::Key_Return: {_controller.calibrate_client(); break; }
   case Qt::Key_Control: {_ctrl_pressed = true; break; }
   case Qt::Key_Alt: {_alt_pressed = true; break; }
@@ -1373,7 +1377,7 @@ void ssr::QUserInterface::_show_about_window()
 
   // text_label.setGeometry(0, 261, 350, 370);
   text_label.setText(about_string.c_str());
-  text_label.setIndent(20);
+  text_label.setIndent(20); 
   text_label.setAlignment(Qt::AlignTop);
   text_label.adjustSize();
 
@@ -1389,7 +1393,7 @@ void ssr::QUserInterface::_show_about_window()
 
   connect(&ssr_logo, SIGNAL(clicked()), &about_window, SLOT(close()));
   connect(&text_label, SIGNAL(clicked()), &about_window, SLOT(close()));
-
+ 
   about_window.exec();
 }
 
@@ -1425,12 +1429,12 @@ void ssr::QUserInterface::_toggle_source_models()
     }
     else if (_scene.get_source_model(i->second) == Source::point)
     {
-      _controller.set_source_model(i->second, Source::plane);
+      _controller.set_source_model(i->second, Source::plane);      
     } // if
   } // for
 }
 
-/** Sets the position fixed state of the currently active mouse.
+/** Sets the position fixed state of the currently active mouse.  
  * @param flag \a true or \a false
  */
 void ssr::QUserInterface::_set_source_position_fixed(const bool flag)
@@ -1438,13 +1442,13 @@ void ssr::QUserInterface::_set_source_position_fixed(const bool flag)
   _controller.set_source_position_fixed(_id_of_last_clicked_source, flag);
 }
 
-/** Sets the position fixed state of the currently active mouse.
- * @param index \a 0="plane wave" \a 1="point source"
+/** Sets the position fixed state of the currently active mouse.  
+ * @param index \a 0="plane wave" \a 1="point source" 
  */
 void ssr::QUserInterface::_set_source_model(const int index)
 {
   Source::model_t model = Source::unknown;
-
+  
   switch(index){
     case 0:
       model = Source::plane;

--- a/src/gui/quserinterface.cpp
+++ b/src/gui/quserinterface.cpp
@@ -1144,11 +1144,7 @@ void ssr::QUserInterface::_update_source_properties_position()
   _get_pixel_pos(source_position->x, source_position->y,
 		 0,&x, &y);
 
-#ifdef __APPLE__
   _source_properties->move(QPoint(this->x() + x + 100, this->y() + y));
-#else
-  _source_properties->move(QPoint(x + 100, y));
-#endif
 
 }
 

--- a/src/gui/quserinterface.h
+++ b/src/gui/quserinterface.h
@@ -34,9 +34,9 @@
 #include <config.h>  // for ENABLE_FLOATING_CONTROL_PANEL
 #endif
 
-#include <QObject>
-#include <QLabel>
-#include <QPushButton>
+#include <QtCore/QObject>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QPushButton>
 
 #include "qopenglplotter.h"
 #include "qclicktextlabel.h"

--- a/src/gui/qvolumeslider.cpp
+++ b/src/gui/qvolumeslider.cpp
@@ -26,9 +26,9 @@
 
 /// @file
 /// TODO: add description
-
-#include <QPainter>
 #include <algorithm>
+
+#include <QtGui/QPainter>
 
 #include "qvolumeslider.h"
 

--- a/src/gui/qvolumeslider.h
+++ b/src/gui/qvolumeslider.h
@@ -30,10 +30,10 @@
 #ifndef SSR_QVOLUMESLIDER_H
 #define SSR_QVOLUMESLIDER_H
 
-#include <QLabel>
-#include <QPoint>
-#include <QMouseEvent>
-#include <QPaintEvent>
+#include <QtCore/QPoint>
+#include <QtGui/QMouseEvent>
+#include <QtGui/QPaintEvent>
+#include <QtWidgets/QLabel>
 
 /// QVolumeSlider
 class QVolumeSlider : public QLabel

--- a/src/gui/qzoomlabel.cpp
+++ b/src/gui/qzoomlabel.cpp
@@ -26,9 +26,9 @@
 
 /// @file
 /// TODO: add description
-
-#include <QPainter>
 #include <algorithm>
+
+#include <QtGui/QPainter>
 
 #include "qzoomlabel.h"
 

--- a/src/gui/qzoomlabel.h
+++ b/src/gui/qzoomlabel.h
@@ -30,10 +30,10 @@
 #ifndef SSR_QZOOMLABEL_H
 #define SSR_QZOOMLABEL_H
 
-#include <QLabel>
-#include <QMouseEvent>
-#include <QPaintEvent>
-#include <QPoint>
+#include <QtCore/QPoint>
+#include <QtGui/QMouseEvent>
+#include <QtGui/QPaintEvent>
+#include <QtWidgets/QLabel>
 
 /// QZoomLabel
 class QZoomLabel : public QLabel


### PR DESCRIPTION
This is a follow up to https://github.com/SoundScapeRenderer/ssr/pull/58.
The property box didn't reflect the mute and fixed source status.
This is because mouse click events were not passed to QCheckBox.