### PR TITLE
Toggle Solo state by key "s"

### DIFF
--- a/src/gui/qgui.cpp
+++ b/src/gui/qgui.cpp
@@ -40,7 +40,7 @@ QString qt_style_sheet =
 #else
   "QWidget {                                               \n"
   "   color: black;                                        \n"
-  "   font: normal 9pt \"Monospace\";                      \n"
+  "   font: normal 10pt \"Monospace\";                     \n"
   "   }                                                    \n"
 #endif
   "QLabel {                                                \n"

--- a/src/gui/qopenglplotter.cpp
+++ b/src/gui/qopenglplotter.cpp
@@ -49,7 +49,7 @@
 
 #define BACKGROUNDCOLOR 0.9294f,0.9294f,0.9020f
 // Define how detailedly circles are plotted
-#define LEVELOFDETAIL 40
+#define LEVELOFDETAIL 50
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation of the nested class QGUI::SourceCopy
@@ -114,12 +114,12 @@ ssr::QOpenGLPlotter::QOpenGLPlotter(Publisher& controller, const Scene& scene
   _soloed_sources.clear();
 
   // define possible colors for sources
-  _color_vector.push_back(QColor(163, 95, 35));
-  _color_vector.push_back(QColor( 43,174,247));
-  _color_vector.push_back(QColor( 75,135, 35));
-  _color_vector.push_back(QColor( 97, 31,160));
-  _color_vector.push_back(QColor(173, 54, 35));
-  //_color_vector.push_back(QColor(242,226, 22));  // yellow is too hard to read
+  _color_vector.push_back(QColor(228, 26, 28));
+  _color_vector.push_back(QColor( 55,126,184));
+  _color_vector.push_back(QColor( 77,175, 74));
+  _color_vector.push_back(QColor(152, 78,163));
+  _color_vector.push_back(QColor(255,127,  0));
+  //http://colorbrewer2.org/?type=qualitative&scheme=Set1&n=5
 
 }
 

--- a/src/gui/qopenglplotter.cpp
+++ b/src/gui/qopenglplotter.cpp
@@ -592,7 +592,14 @@ ssr::QOpenGLPlotter::_draw_source(source_buffer_list_t::const_iterator& source,
   gluDisk(_glu_quadric, 0.0f, 0.15f * scale, LEVELOFDETAIL, 1);
 
   // fill source
-  qglColor(_color_vector[source->id%_color_vector.size()]);
+  if (source->mute)
+  {
+    qglColor(_color_vector[source->id%_color_vector.size()].darker(180));
+  }
+  else
+  {
+    qglColor(_color_vector[source->id%_color_vector.size()]);
+  }
 
   gluPartialDisk(_glu_quadric, 0.0f, 0.125f * scale,
                  LEVELOFDETAIL, 1, 0.0f, 360.0f);


### PR DESCRIPTION
The key "s" did not toggle the solo state, as you would expect it from all other multitrack audio softwares I'm familiar with. Very inconvenient, especially for demos, as you have to unselect all sources first and then hit "s" again.
The key "m" already shows the expected behaviour for mute (toggle) state.

- This PR improves the shortcut "s" and matches it to shortcut "m"