### PR TITLE
make the meaning of asio.hpp self-explanatory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -522,7 +522,7 @@ ENABLE_EXPLICIT([floating-control-panel], [separate control window],
   AS_IF([test x$have_gui = xno], [have_floating_control_panel=no])
 ])
 
-ENABLE_FORCED([ip-interface], [network (TCP/IP) interface],
+ENABLE_FORCED([ip-interface], [network (TCP/IP) interface (needs libasio, https://think-async.com/)],
 [
   CPPFLAGS="$CPPFLAGS -DASIO_STANDALONE"
   AC_CHECK_HEADER([asio.hpp], , [have_ip_interface=no])
@@ -769,7 +769,7 @@ echo "|    Razor AHRS .......................... : $have_razor"
 echo "|    VRPN ................................ : $have_vrpn"
 echo "|"
 echo "| Build with Ecasound support ............ : $have_ecasound"
-echo "| Build with IP interface ................ : $have_ip_interface"
+echo "| Build with libasio IP interface ........ : $have_ip_interface"
 echo "| Build with GUI ......................... : $gui_string"
 echo "|"
 echo "| Enable debugging/optimization .......... : $have_debugging/$have_optimization"


### PR DESCRIPTION
Be a bit more explicit about libasio being necessary for the IP interface (and avoid confusion with the Windows audio interface).