### PR TITLE
src/controller.h: Wrapping call to Subscriber::set_source_orientation…

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -1534,10 +1534,12 @@ void
 Controller<Renderer>::orient_source_toward_reference(const id_t id)
 {
   // take reference offset into account?
-  
-  _publish(&Subscriber::set_source_orientation, id
-    , (_scene.get_reference().position - 
-        *_scene.get_source_position(id)).orientation());
+  if (_scene.get_source_orientation(id))
+  {
+    _publish(&Subscriber::set_source_orientation, id
+      , (_scene.get_reference().position - 
+          *_scene.get_source_position(id)).orientation());
+  }
 }
 
 template<typename Renderer>

--- a/src/controller.h
+++ b/src/controller.h
@@ -1534,11 +1534,10 @@ void
 Controller<Renderer>::orient_source_toward_reference(const id_t id)
 {
   // take reference offset into account?
-  if (_scene.get_source_position(id))
+  if (auto src_pos = _scene.get_source_position(id))
   {
     _publish(&Subscriber::set_source_orientation, id
-      , (_scene.get_reference().position - 
-          *_scene.get_source_position(id)).orientation());
+      , (_scene.get_reference().position - *src_pos).orientation());
   }
 }
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -1534,7 +1534,7 @@ void
 Controller<Renderer>::orient_source_toward_reference(const id_t id)
 {
   // take reference offset into account?
-  if (_scene.get_source_orientation(id))
+  if (_scene.get_source_position(id))
   {
     _publish(&Subscriber::set_source_orientation, id
       , (_scene.get_reference().position - 


### PR DESCRIPTION
…() in a call to Scene::get_source_orientation() first, to make the former not segfault, if a non-existent Source is supplied.