### PR TITLE
Remove compile-time check for _REENTRANT in cxx_thread_policy.h

### DIFF
--- a/apf/apf/cxx_thread_policy.h
+++ b/apf/apf/cxx_thread_policy.h
@@ -27,10 +27,6 @@
 #ifndef APF_CXX_THREAD_POLICY_H
 #define APF_CXX_THREAD_POLICY_H
 
-#ifndef _REENTRANT
-#error You need to compile with _REENTRANT defined since this uses threads!
-#endif
-
 #ifndef APF_MIMOPROCESSOR_THREAD_POLICY
 #define APF_MIMOPROCESSOR_THREAD_POLICY apf::cxx_thread_policy
 #endif


### PR DESCRIPTION
This was removed from the rest of the code base in commit b50218f59ed379ad3645a04bdb37fd72475f5ff4.

Closes #91.