### PR TITLE
Replace sleep() and usleep() by c++11

### DIFF
--- a/apf/apf/commandqueue.h
+++ b/apf/apf/commandqueue.h
@@ -30,7 +30,8 @@
 #ifndef APF_COMMANDQUEUE_H
 #define APF_COMMANDQUEUE_H
 
-#include <unistd.h> // for usleep()
+#include <thread>   // std::this_thread::sleep_for
+#include <chrono>   // std::chrono::microseconds
 #include <cassert>  // for assert()
 
 #include "apf/lockfreefifo.h"
@@ -207,8 +208,8 @@ void CommandQueue::push(Command* cmd)
   {
     // We don't really know if that ever happens, so we abort in debug-mode:
     assert(false && "Error in _in_fifo.push()!");
-    // TODO: avoid this usleep()?
-    usleep(50);
+    // TODO: avoid this sleep?
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
   }
 }
 
@@ -223,8 +224,8 @@ void CommandQueue::wait()
   this->cleanup_commands();
   while (!done)
   {
-    // TODO: avoid this usleep()?
-    usleep(50);
+    // TODO: avoid this sleep?
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
     this->cleanup_commands();
   }
 }

--- a/data/MacOSX/dylibbundler/src/Utils.cpp
+++ b/data/MacOSX/dylibbundler/src/Utils.cpp
@@ -19,7 +19,6 @@
 #include "Dependency.h"
 #include "Settings.h"
 #include <cstdlib>
-#include <unistd.h>
 #include <iostream>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/src/audioplayer.cpp
+++ b/src/audioplayer.cpp
@@ -27,8 +27,10 @@
 /// @file
 /// Audio player using ecasound (implementation).
 
-#include <jack/jack.h> // for jack_client_name_size()
 #include <algorithm>
+#include <thread>   // std::this_thread::sleep_for
+#include <chrono>   // std::chrono::microseconds
+#include <jack/jack.h> // for jack_client_name_size()
 
 #include "audioplayer.h"
 #include "maptools.h"
@@ -282,7 +284,7 @@ AudioPlayer::Soundfile::Soundfile(const std::string& filename, bool loop,
   // It takes a little time until the client is available
   // This is a little ugly, but I don't know a better way to do it.
   // If you know one, tell me, please!
-  usleep(ssr::usleeptime);
+  std::this_thread::sleep_for(std::chrono::microseconds(ssr::usleeptime));
   VERBOSE2("Added '" + _filename
       + "', format: '" + apf::str::A2S(_sample_format)
       + "', channels: " + apf::str::A2S(_channels)

--- a/src/audiorecorder.cpp
+++ b/src/audiorecorder.cpp
@@ -27,7 +27,8 @@
 /// @file
 /// Audio recorder using ecasound (implementation).
 
-#include <unistd.h>  // for usleep()
+#include <thread>   // std::this_thread::sleep_for
+#include <chrono>   // std::chrono::microseconds
 
 #include "audiorecorder.h"
 #include "ssr_global.h"
@@ -102,7 +103,7 @@ AudioRecorder::AudioRecorder(const std::string& audio_file_name,
   // It takes a little time until the client is available
   // This is a little ugly, but I don't know a better way to do it.
   // If you know one, tell me, please!
-  usleep(ssr::usleeptime);
+  std::this_thread::sleep_for(std::chrono::microseconds(ssr::usleeptime));
 }
 
 /// disconnects from ecasound

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -30,16 +30,15 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h> // for ENABLE_*, HAVE_*, WITH_*
 #endif
-#ifdef ENABLE_ISATTY
-#include <thread>   // std::this_thread::sleep_for
-#include <chrono>   // std::chrono::seconds
-#endif
 
 #include <cassert>      // for assert()
 #include <getopt.h>     // for getopt_long()
 #include <cstdlib>      // for getenv(), ...
 #include <cstring>
 #include <stdio.h>
+#include <thread>   // std::this_thread::sleep_for
+#include <chrono>   // std::chrono::seconds
+
 #include "configuration.h"
 #include "posixpathtools.h"
 #include "apf/stringtools.h"

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -31,7 +31,8 @@
 #include <config.h> // for ENABLE_*, HAVE_*, WITH_*
 #endif
 #ifdef ENABLE_ISATTY
-#include <unistd.h>
+#include <thread>   // std::this_thread::sleep_for
+#include <chrono>   // std::chrono::seconds
 #endif
 
 #include <cassert>      // for assert()
@@ -64,7 +65,7 @@ namespace // anonymous
     {
       std::cout << "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
         "It's ... " << std::flush;
-      sleep(3);
+      std::this_thread::sleep_for(std::chrono::seconds(3));
       std::cout << "the ";
     }
     std::cout << PACKAGE_STRING "\n" SSR_COPYRIGHT << std::endl;

--- a/src/razor-ahrs/RazorAHRS.cpp
+++ b/src/razor-ahrs/RazorAHRS.cpp
@@ -12,6 +12,9 @@
 *     https://github.com/ptrbrtz/razor-9dof-ahrs
 ******************************************************************************************/
 
+#include <thread>   // std::this_thread::sleep_for
+#include <chrono>   // std::chrono::milliseconds
+
 #include "RazorAHRS.h"
 #include <cassert>
 
@@ -149,7 +152,7 @@ RazorAHRS::_init_razor()
     }
     // no data available
     else if (result == 0)
-      usleep(1000); // sleep 1ms
+      std::this_thread::sleep_for(std::chrono::milliseconds(1)); // sleep 1ms
     // error?
     else
     {

--- a/src/trackerintersense.cpp
+++ b/src/trackerintersense.cpp
@@ -31,7 +31,8 @@
 #include <config.h>  // for ENABLE_*, HAVE_*, WITH_*
 #endif
 
-#include <unistd.h>
+#include <thread>   // std::this_thread::sleep_for
+#include <chrono>   // std::chrono::milliseconds
 #include <fstream>
 
 #include "trackerintersense.h"
@@ -122,7 +123,7 @@ ssr::TrackerInterSense::TrackerInterSense(Publisher& controller
     _start();
 
     // wait 100ms to make sure that tracker gives reliable values
-    usleep(100000u);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     // and then calibrate it
     calibrate();
   }
@@ -200,7 +201,7 @@ void* ssr::TrackerInterSense::thread(void *arg)
 #endif
 
     // wait a bit
-    usleep(_read_interval*1000u);
+    std::this_thread::sleep_for(std::chrono::microseconds(_read_interval*1000u));
   };
 
   return arg;

--- a/src/trackerpolhemus.cpp
+++ b/src/trackerpolhemus.cpp
@@ -33,6 +33,8 @@
 #include <sstream>   // for std::stringstream
 #include <poll.h>    // for poll(), pollfd, ...
 #include <cassert>   // for assert()
+#include <thread>    // std::this_thread::sleep_for
+#include <chrono>    // std::chrono::milliseconds
 
 #include "trackerpolhemus.h"
 #include "publisher.h"
@@ -138,7 +140,7 @@ ssr::TrackerPolhemus::TrackerPolhemus(Publisher& controller
   _start();
 
   // wait until tracker has started
-  usleep(50000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
   this->calibrate();
 }


### PR DESCRIPTION
sleep() and usleep() are obsolete posix specific implementations and should be replaced by the c++11 standard library.  
It's also specific about the time unit and we get rid of a lot `#include <unistd.h>`.