### PR TITLE
add reference offset orientation for BRS Renderer

### DIFF
--- a/src/brsrenderer.h
+++ b/src/brsrenderer.h
@@ -144,9 +144,9 @@ class BrsRenderer::Source : public _base::Source
 
       _weighting_factor = this->weighting_factor;
 
-      float azi = this->parent.state.reference_orientation.get().azimuth;
-
-      // TODO: get reference offset!
+      auto ori = _input.parent.state.reference_orientation
+        + _input.parent.state.reference_offset_orientation;
+      float azi = ori.azimuth;
 
       // get BRTF index from listener orientation
       // (source positions are NOT considered!)


### PR DESCRIPTION
Incorporates the reference_offset for the BRIR rendering.

tested with
```
echo -e '<request><reference_offset><orientation azimuth="0"/></reference_offset></request>\0' | nc localhost 4711
```