### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ language: cpp
 git:
   depth: 3
 
+dist: trusty
+sudo: required
+osx_image: xcode9.2
+
 compiler:
   - clang
   - gcc
 
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-    - os: osx
-      osx_image: xcode9.2
+os:
+  - osx
+  - linux
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && sudo make install; fi
 
 after_failure:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ls -alhv /usr/bin/ |grep -E "(clang|gcc|g++)"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ls -alhv /usr/bin/ |grep -E "(clang|gcc|g\+\+)"; fi
   - if [[ -f config.log ]]; then cat config.log; fi
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 
+env:
+
 compiler:
   - clang
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 
+compiler:
+  - clang
+  - gcc
+
 matrix:
   include:
     - os: linux
@@ -9,17 +13,16 @@ matrix:
       osx_image: xcode9.2
       env:
         - PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-
-compiler:
-  - clang
-  - gcc
+  allow_failures:
+    - compiler: clang
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo rm /usr/local/include/c++; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install asio --c++11 autoconf doxygen ecasound fftw help2man jack libsndfile qt; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --c++11 asio autoconf doxygen ecasound fftw help2man jack libsndfile qt4; fi
   # autotools, automake, make are present in the trusty image
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y g++ libasio-dev libqt4-dev libqt4-opengl-dev libecasoundc-dev ecasound libxml2-dev libfftw3-dev libsndfile1-dev libjack-dev libjack0 jackd1 pkg-config libtool; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && sudo make install; fi
 
 after_failure:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ls -alhv /usr/bin/ |grep -E "(clang|gcc|g++)"; fi
   - if [[ -f config.log ]]; then cat config.log; fi
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             - g++-6
       dist: trusty
       env:
-        - MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
+        - CC=gcc-6 CXX=g++-6
       compiler: gcc
     # linux with gcc (current)
     - os: linux
@@ -36,7 +36,7 @@ matrix:
             - clang-3.8
       dist: trusty
       env:
-        - MATRIX_EVAL="CC=clang-3.8 CXX=clang++-3.8"
+        - CC=clang-3.8 CXX=clang++-3.8
       compiler: clang
     # osx with xcode9.2/gcc
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             - g++-6
       dist: trusty
       env:
-        - CC=gcc-6 CXX=g++-6
+        - MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
       compiler: gcc
     # linux with gcc (current)
     - os: linux
@@ -25,6 +25,8 @@ matrix:
     # linux with clang (current)
     - os: linux
       dist: trusty
+      env:
+        - MATRIX_EVAL="COMPILE_ASIO=1"
       compiler: clang
     # linux with clang 3.8
     - os: linux
@@ -36,7 +38,7 @@ matrix:
             - clang-3.8
       dist: trusty
       env:
-        - CC=clang-3.8 CXX=clang++-3.8
+        - MATRIX_EVAL="CC=clang-3.8 CXX=clang++-3.8 COMPILE_ASIO=1"
       compiler: clang
     # osx with xcode9.2/gcc
     - os: osx
@@ -56,6 +58,7 @@ matrix:
       compiler: clang
 
 before_install:
+  - eval "${MATRIX_EVAL}"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo rm /usr/local/include/c++; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ env:
 
 matrix:
   include:
+    # linux with gcc 7
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          install:
+            - gcc-7
+      dist: trusty
+      env:
+        - MATRIX_EVAL="CC=gcc-7 CXX=g++-7"
+      compiler: gcc
     # linux with gcc 6
     - os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 
-env:
+git:
+  depth: 3
 
 compiler:
   - clang
@@ -13,10 +14,6 @@ matrix:
       sudo: required
     - os: osx
       osx_image: xcode9.2
-      env:
-        - PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-          #  allow_failures:
-          #    - compiler: clang
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
@@ -28,6 +25,7 @@ install:
 
 before_script:
   - ci/build-deps.sh
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig; fi
   - autoreconf -vfi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install asio --c++11 autoconf doxygen ecasound fftw help2man jack libsndfile qt; fi
   # autotools, automake, make are present in the trusty image
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y g++ libasio-dev libqt4-dev libqt4-opengl-dev libecasoundc-dev ecasound libxml2-dev libfftw3-dev libsndfile1-dev libjack-dev jackd pkg-config libtool; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y g++ libasio-dev libqt4-dev libqt4-opengl-dev libecasoundc-dev ecasound libxml2-dev libfftw3-dev libsndfile1-dev libjack-dev libjack0 jackd1 pkg-config libtool; fi
 
 before_script:
   - ci/install-deps.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       osx_image: xcode9.2
       env:
         - PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+        - PATH=/usr/local/opt/gettext/bin:$PATH
           #  allow_failures:
           #    - compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           install:
-            - g++-6
+            - gcc-6
       dist: trusty
       env:
         - MATRIX_EVAL="CC=gcc-6 CXX=g++-6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,59 @@
 language: cpp
+sudo: required
 
 git:
   depth: 3
 
-dist: trusty
-sudo: required
-osx_image: xcode9.2
-
-compiler:
-  - clang
-  - gcc
-
-os:
-  - osx
-  - linux
+matrix: 
+  include:
+    # linux with gcc 6
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          install:
+            - g++-6
+      dist: trusty
+      env:
+        - MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
+      compiler: gcc
+    # linux with gcc (current)
+    - os: linux
+      dist: trusty
+      compiler: gcc
+    # linux with clang (current)
+    - os: linux
+      dist: trusty
+      compiler: clang
+    # linux with clang 3.8
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          install:
+            - clang-3.8
+      dist: trusty
+      env:
+        - MATRIX_EVAL="CC=clang-3.8 CXX=clang++-3.8"
+      compiler: clang
+    # osx with xcode9.2/gcc
+    - os: osx
+      osx_image: xcode9.2
+      compiler: gcc
+    # osx with xcode9.2/clang
+    - os: osx
+      osx_image: xcode9.2
+      compiler: clang
+    # osx with xcode8/gcc
+    - os: osx
+      osx_image: xcode8
+      compiler: gcc
+    # osx with xcode8/clang
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
@@ -43,4 +83,6 @@ branches:
     - networking-with-osc
     - travis-integration
 
+notifications:
+  email: false
 # vim:set ts=2 sw=2 et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode9.2
+      env:
+        - PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install asio --c++11 autoconf doxygen ecasound fftw help2man jack libsndfile qt; fi
+  # autotools, automake, make are present in the trusty image
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y g++ libasio-dev libqt4-dev libqt5-opengl-dev libecasoundc-dev ecasound libxml2-dev libfftw3-dev libsndfile1-dev libjack-dev jackd pkg-config libtool; fi
+
+before_script:
+  - ci/install-deps.sh
+  - autoreconf -vfi
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure --enable-app-bundle; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure --prefix='/usr'; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make dmg; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && sudo make install; fi
+
+branches:
+  only:
+    - master
+    - networking-with-osc
+
+# vim:set ts=2 sw=2 et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 
 compiler:
-  #  - clang
+  - clang
   - gcc
 
 matrix:
@@ -13,7 +13,6 @@ matrix:
       osx_image: xcode9.2
       env:
         - PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-        - PATH=/usr/local/opt/gettext/bin:$PATH
           #  allow_failures:
           #    - compiler: clang
 
@@ -34,6 +33,9 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure --prefix='/usr'; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make dmg; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && sudo make install; fi
+
+after_failure:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] -a [[ -f config.log ]]; then cat config.log; fi
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,6 @@ branches:
   only:
     - master
     - networking-with-osc
+    - travis-integration
 
 # vim:set ts=2 sw=2 et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 
 compiler:
-  - clang
+  #  - clang
   - gcc
 
 matrix:
@@ -13,8 +13,8 @@ matrix:
       osx_image: xcode9.2
       env:
         - PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-  allow_failures:
-    - compiler: clang
+          #  allow_failures:
+          #    - compiler: clang
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --c++11 asio autoconf doxygen ecasound fftw help2man jack libsndfile qt4; fi
-  # autotools, automake, make are present in the trusty image
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y g++ libasio-dev libqt4-dev libqt4-opengl-dev libecasoundc-dev ecasound libxml2-dev libfftw3-dev libsndfile1-dev libjack-dev libjack0 jackd1 pkg-config libtool; fi
+  - ci/install-deps.sh
 
 before_script:
-  - ci/install-deps.sh
+  - ci/build-deps.sh
   - autoreconf -vfi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install asio --c++11 autoconf doxygen ecasound fftw help2man jack libsndfile qt; fi
   # autotools, automake, make are present in the trusty image
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y g++ libasio-dev libqt4-dev libqt5-opengl-dev libecasoundc-dev ecasound libxml2-dev libfftw3-dev libsndfile1-dev libjack-dev jackd pkg-config libtool; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y g++ libasio-dev libqt4-dev libqt4-opengl-dev libecasoundc-dev ecasound libxml2-dev libfftw3-dev libsndfile1-dev libjack-dev jackd pkg-config libtool; fi
 
 before_script:
   - ci/install-deps.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
       compiler: gcc
-    # linux with gcc (current)
+    # linux with gcc (default)
     - os: linux
       dist: trusty
       compiler: gcc
-    # linux with clang (current)
+    # linux with clang (default)
     - os: linux
       dist: trusty
       env:
@@ -64,13 +64,11 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       compiler: clang
-    # osx with xcode8/gcc
+    # osx with xcode/gcc (default)
     - os: osx
-      osx_image: xcode8
       compiler: gcc
-    # osx with xcode8/clang
+    # osx with xcode/clang (default)
     - os: osx
-      osx_image: xcode8
       compiler: clang
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && sudo make install; fi
 
 after_failure:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] -a [[ -f config.log ]]; then cat config.log; fi
+  - if [[ -f config.log ]]; then cat config.log; fi
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ sudo: required
 git:
   depth: 3
 
-matrix: 
+env:
+  global:
+    - COMPILE_ASIO=0
+
+matrix:
   include:
     # linux with gcc 6
     - os: linux

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -11,9 +11,4 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   cd ..
 fi
 
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-  # help2man requires perl's Locale::gettext
-  # don't test the installation
-  sudo cpanm -n Locale:gettext
-fi
 exit 0

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -9,6 +9,17 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   ./configure && make && sudo make install
   sudo ldconfig
   cd ..
+  if [ $COMPILE_ASIO -eq 1 ]; then
+    # remove previously installed asio, as we're trying a newer version
+    sudo apt-get remove asio
+    # compile and install asio 1.12.0
+    wget https://github.com/chriskohlhoff/asio/archive/asio-1-12-0.tar.gz
+    tar xvf asio-1-12-0.tar.gz
+    cd asio-asio-1-12-0/asio
+    ./configure --with-boost=no --prefix=/usr
+    make
+    sudo make install
+  fi
 fi
 
 exit 0

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -13,6 +13,7 @@ fi
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   # help2man requires perl's Locale::gettext
-  cpanm Locale:gettext
+  # don't test the installation
+  sudo cpanm -n Locale:gettext
 fi
 exit 0

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -10,4 +10,9 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   sudo ldconfig
   cd ..
 fi
+
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  # help2man requires perl's Locale::gettext
+  cpanm Locale:gettext
+fi
 exit 0

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -11,7 +11,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   cd ..
 fi
 
-if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   # help2man requires perl's Locale::gettext
   cpanm Locale:gettext
 fi

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -11,7 +11,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   cd ..
   if [ $COMPILE_ASIO -eq 1 ]; then
     # remove previously installed asio, as we're trying a newer version
-    sudo apt-get remove asio
+    sudo apt-get remove libasio-dev
     # compile and install asio 1.12.0
     wget https://github.com/chriskohlhoff/asio/archive/asio-1-12-0.tar.gz
     tar xvf asio-1-12-0.tar.gz

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -16,6 +16,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     wget https://github.com/chriskohlhoff/asio/archive/asio-1-12-0.tar.gz
     tar xvf asio-1-12-0.tar.gz
     cd asio-asio-1-12-0/asio
+    autoreconf -vfi
     ./configure --with-boost=no --prefix=/usr
     make
     sudo make install

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  # liblo-dev is still at 0.28 in trusty, but we require 0.29
+  wget https://downloads.sourceforge.net/liblo/liblo-0.29.tar.gz
+  tar xvf liblo-0.29.tar.gz && cd liblo-0.29
+  ./configure && make && sudo make install
+  sudo ldconfig
+  cd ..
+fi
+exit 0

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -29,12 +29,14 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     libqt4-dev \
     libqt4-opengl-dev \
     libecasoundc-dev \
+    doxygen \
     ecasound \
     libxml2-dev \
     libfftw3-dev \
     libsndfile1-dev \
     libjack-dev \
     libjack0 \
+    help2man \
     jackd1 \
     pkg-config \
     libtool

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-
-
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   # brew rightfully abandoned qt4
   # https://github.com/cartr/homebrew-qt4
@@ -11,12 +9,13 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   brew tap-pin cartr/qt4
   brew install --c++11 asio \
     autoconf \
+    cpanminus \
     doxygen \
     ecasound \
     fftw \
-    gettext \
     help2man \
     jack \
+    liblo \
     libsndfile \
     qt@4
 fi

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -2,12 +2,41 @@
 
 set -euo pipefail
 
-if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-  # liblo-dev is still at 0.28 in trusty, but we require 0.29
-  wget https://downloads.sourceforge.net/liblo/liblo-0.29.tar.gz
-  tar xvf liblo-0.29.tar.gz && cd liblo-0.29
-  ./configure && make && sudo make install
-  sudo ldconfig
-  cd ..
+
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  # brew rightfully abandoned qt4
+  # https://github.com/cartr/homebrew-qt4
+  brew tap cartr/qt4
+  brew tap-pin cartr/qt4
+  brew install --c++11 asio \
+    autoconf \
+    doxygen \
+    ecasound \
+    fftw \
+    help2man \
+    jack \
+    libsndfile \
+    qt@4
 fi
+
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  # autotools, automake, make are present in the trusty image
+  sudo apt-get install -y \
+    g++ \
+    libasio-dev \
+    libqt4-dev \
+    libqt4-opengl-dev \
+    libecasoundc-dev \
+    ecasound \
+    libxml2-dev \
+    libfftw3-dev \
+    libsndfile1-dev \
+    libjack-dev \
+    libjack0 \
+    jackd1 \
+    pkg-config \
+    libtool
+fi
+
 exit 0

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -40,6 +40,18 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     jackd1 \
     pkg-config \
     libtool
+  # force installation of gcc-6 if required
+  if [ "${CC}" == "gcc-6" ]; then
+    sudo apt-get install gcc-6
+  fi
+  # force installation of gcc-7 if required
+  if [ "${CC}" == "gcc-7" ]; then
+    sudo apt-get install gcc-7
+  fi
+  # force installation of clang-3.8 if required
+  if [ "${CC}" == "clang-3.8" ]; then
+    sudo apt-get install clang-3.8
+  fi
 fi
 
 exit 0

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -7,13 +7,15 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   # https://github.com/cartr/homebrew-qt4
   brew tap cartr/qt4
   brew tap-pin cartr/qt4
-  brew install --c++11 asio \
+  brew install --c++11 \
+    asio \
     autoconf \
     ecasound \
     fftw \
     jack \
     liblo \
     libsndfile \
+    libxml2 \
     qt@4
   # using brew, it's not possible to install needed perl dependencies for
   # help2man (Locale::gettext), therefore best disabled for now

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -42,11 +42,11 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     libtool
   # force installation of gcc-6 if required
   if [ "${CC}" == "gcc-6" ]; then
-    sudo apt-get install gcc-6
+    sudo apt-get install gcc-6 g++-6
   fi
   # force installation of gcc-7 if required
   if [ "${CC}" == "gcc-7" ]; then
-    sudo apt-get install gcc-7
+    sudo apt-get install gcc-7 g++-7
   fi
   # force installation of clang-3.8 if required
   if [ "${CC}" == "clang-3.8" ]; then

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -14,6 +14,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     doxygen \
     ecasound \
     fftw \
+    gettext \
     help2man \
     jack \
     libsndfile \

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  # liblo-dev is still at 0.28 in trusty, but we require 0.29
+  wget https://downloads.sourceforge.net/liblo/liblo-0.29.tar.gz
+  tar xvf liblo-0.29.tar.gz && cd liblo-0.29
+  ./configure && make && sudo make install
+  sudo ldconfig
+  cd ..
+fi
+exit 0

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -9,15 +9,16 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   brew tap-pin cartr/qt4
   brew install --c++11 asio \
     autoconf \
-    cpanminus \
-    doxygen \
     ecasound \
     fftw \
-    help2man \
     jack \
     liblo \
     libsndfile \
     qt@4
+  # using brew, it's not possible to install needed perl dependencies for
+  # help2man (Locale::gettext), therefore best disabled for now
+#    doxygen \
+#    help2man \
 fi
 
 if [ "$TRAVIS_OS_NAME" == "linux" ]; then


### PR DESCRIPTION
This adds travis integration. Automated builds for:

- linux (ubuntu trusty based): gcc 4.8.4 (current), gcc6, gcc7 (still fails because of #81), clang 3.8, clang 5.0.0
- macOS (Xcode 8.3, XCode 9.2): gcc and clang (the former being abstracted by llvm) (all have help2man disabled, because on macOS it doesn't have `Locale::gettext` and will fail during build).

Please note: For clang on linux (ubuntu trusty) asio had to be built from source, as the build process is failing with the included version (0.10.1). It is now at 0.12.0.
Also, I'm already building liblo 0.29 (trusty and most other ubuntu versions are still stuck on 0.28) from source in preparation for testing and merging my native OSC interface in the future.

See #96 for reference.