### PR TITLE
Change name NFC-HOA to DCA and update manual

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,7 @@ dist_noinst_DATA = \
 	mex/ssr_mex.h \
 	mex/ssr_aap.cpp \
 	mex/ssr_binaural.cpp \
-	mex/ssr_nfc_hoa.cpp \
+	mex/ssr_dca.cpp \
 	mex/ssr_vbap.cpp \
 	mex/ssr_wfs.cpp \
 	mex/ssr_helper.m \
@@ -52,13 +52,13 @@ dist_noinst_DATA = \
 	flext/ssr_flext.h \
 	flext/ssr_aap.cpp \
 	flext/ssr_binaural.cpp \
-	flext/ssr_nfc_hoa.cpp \
+	flext/ssr_dca.cpp \
 	flext/ssr_vbap.cpp \
 	flext/ssr_wfs.cpp \
 	flext/ssr_messages.pd \
 	flext/ssr_aap~-help.pd \
 	flext/ssr_binaural~-help.pd \
-	flext/ssr_nfc_hoa~-help.pd \
+	flext/ssr_dca~-help.pd \
 	flext/ssr_vbap~-help.pd \
 	flext/ssr_wfs~-help.pd \
 	flext/virtual_vbap.pd \

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ dist_noinst_DATA = \
 	mex/ssr_wfs.cpp \
 	mex/ssr_helper.m \
 	mex/test_ssr.m \
+	flext/README.md \
 	flext/Makefile \
 	flext/package.txt \
 	flext/ssr_flext.h \
@@ -61,6 +62,8 @@ dist_noinst_DATA = \
 	flext/ssr_dca~-help.pd \
 	flext/ssr_vbap~-help.pd \
 	flext/ssr_wfs~-help.pd \
+	flext/virtual_aap.pd \
+	flext/virtual_dca.pd \
 	flext/virtual_vbap.pd \
 	flext/virtual_wfs.pd \
 	flext/8channels.asd \

--- a/apf/performance_tests/biquad_count_denormals.cpp
+++ b/apf/performance_tests/biquad_count_denormals.cpp
@@ -74,7 +74,7 @@ int main()
   benign_flt.a1 = 0.5f;        benign_dbl.a1 = 0.5;
   benign_flt.a2 = 0.2f;        benign_dbl.a2 = 0.2;
 
-  // HPF similar to the one used in HOA algorithm
+  // HPF similar to the one used in DCA algorithm
   malignant_flt.b0 =  0.98f;   malignant_dbl.b0 =  0.98;
   malignant_flt.b1 = -1.9f;    malignant_dbl.b1 = -1.9;
   malignant_flt.b2 =  0.93f;   malignant_dbl.b2 =  0.93;

--- a/apf/performance_tests/biquad_denormals.cpp
+++ b/apf/performance_tests/biquad_denormals.cpp
@@ -78,7 +78,7 @@ int main()
   benign_flt.a1 = 0.5f;        benign_dbl.a1 = 0.5;
   benign_flt.a2 = 0.2f;        benign_dbl.a2 = 0.2;
 
-  // HPF similar to the one used in NFC-HOA algorithm
+  // HPF similar to the one used in DCA algorithm
   malignant_flt.b0 =  0.98f;   malignant_dbl.b0 =  0.98;
   malignant_flt.b1 = -1.9f;    malignant_dbl.b1 = -1.9;
   malignant_flt.b2 =  0.93f;   malignant_dbl.b2 =  0.93;

--- a/configure.ac
+++ b/configure.ac
@@ -175,10 +175,10 @@ ENABLE_AUTO([generic], [generic renderer],
     [SSR_executables="$SSR_executables ssr-generic"])
 ])
 
-ENABLE_AUTO([nfc-hoa],[Near-Field-Compensated Higher-Order-Ambisonics renderer],
+ENABLE_AUTO([dca],[Distance-coded Ambisonics renderer],
 [
-  AS_IF([test x$enable_nfc_hoa = xyes -o x$have_all = xyes],
-    [SSR_executables="$SSR_executables ssr-nfc-hoa"])
+  AS_IF([test x$enable_dca = xyes -o x$have_all = xyes],
+    [SSR_executables="$SSR_executables ssr-dca"])
 ])
 
 dnl Note: For what happens with SSR_executables see src/Makefile.am

--- a/data/MacOSX/run-ssr.applescript
+++ b/data/MacOSX/run-ssr.applescript
@@ -8,8 +8,8 @@ on run argv
 	set argv to rest of argv
 
 	-- Make list of renderer type names and their parameter equivalents
-	set rendererNames to {"Binaural (using HRIRs)", "Binaural Room Synthesis (using BRIRs)", "Wave Field Synthesis", "Ambisonics Amplitude Panning", "Stereophonic (Vector Base Amplitude Panning)", "Generic Renderer"}
-	set rendererOptions to {"--binaural", "--brs", "--wfs", "--aap", "--vbap", "--generic"}
+	set rendererNames to {"Binaural (using HRIRs)", "Binaural Room Synthesis (using BRIRs)", "Stereophonic (Vector Base Amplitude Panning)", "Wave Field Synthesis", "Ambisonics Amplitude Panning", "Distance-Coded Ambisonics (experimental)", "Generic Renderer"}
+	set rendererOptions to {"--binaural", "--brs", "--vbap", "--wfs", "--aap", "--dca", "--generic"}
 
 	-- Process other given command line options
 	set pickRendererType to true

--- a/data/ssr
+++ b/data/ssr
@@ -27,8 +27,8 @@ while [[ $1 ]]; do
     --generic)
       SSR_EXECUTABLE=ssr-generic
       ;;
-    --nfc-hoa)
-      SSR_EXECUTABLE=ssr-nfc-hoa
+    --dca)
+      SSR_EXECUTABLE=ssr-dca
       ;;
     *)
       OPTIONS+=("$1")

--- a/doc/manual/operation.rst
+++ b/doc/manual/operation.rst
@@ -280,9 +280,9 @@ an overview of the command line options and various renderers:
         --brs              Binaural Room Synthesis (using BRIRs)
         --wfs              Wave Field Synthesis
         --aap              Ambisonics Amplitude Panning
+        --dca              Distance-coded Ambisonics (experimental!)
         --vbap             Stereophonic (Vector Base Amplitude Panning)
         --generic          Generic Renderer
-        --nfc-hoa          Near-field-corrected Higher Order Ambisonics (experimental!)
 
     Renderer-specific options:
         --hrirs=FILE       Load the HRIRs for binaural renderer from FILE

--- a/doc/manual/renderers.rst
+++ b/doc/manual/renderers.rst
@@ -266,6 +266,8 @@ approach which is computationally significantly more costly.
 Binaural Renderer
 -----------------
 
+Executable: ``ssr-binaural``
+
 Binaural rendering is an approach where the acoustical influence of the
 human head is electronically simulated to position virtual sound sources
 in space. **Be sure that you are using headphones to listen.**
@@ -398,6 +400,8 @@ the KEMAR (CIPIC) HRIRs are not identical to the KEMAR (QU) ones.
 Binaural Room Synthesis Renderer
 --------------------------------
 
+Executable: ``ssr-brs``
+
 The Binaural Room Synthesis (BRS) renderer is a binaural renderer (refer
 to Section :ref:`Binaural Renderer <binaural_renderer>`) which uses one
 dedicated
@@ -460,6 +464,8 @@ them in the release. You can obtain the data from [BRIRs]_.
 
 Vector Base Amplitude Panning Renderer
 --------------------------------------
+
+Executable: ``ssr-vbap``
 
 The Vector Base Amplitude Panning (VBAP) renderer uses the algorithm
 described in [Pulkki1997]_. It tries to find a loudspeaker pair between which
@@ -531,6 +537,8 @@ setups.
 
 Wave Field Synthesis Renderer
 -----------------------------
+
+Executable: ``ssr-wfs``
 
 The Wave Field Synthesis (WFS) renderer is the only renderer so far
 that discriminates between virtual point sources and plane waves. It
@@ -631,6 +639,8 @@ respective loudspeaker. It defaults to 1 if it is not specified.
 Ambisonics Amplitude Panning Renderer
 -------------------------------------
 
+Executable: ``ssr-aap``
+
 The Ambisonics Amplitude Panning (AAP) renderer does very simple
 Ambisonics rendering. It does amplitude panning by simultaneously using
 all loudspeakers that are not subwoofers to reproduce a virtual source
@@ -716,10 +726,28 @@ section :ref:`Configuration File <ssr_configuration_file>`) to be
 .. [Neukom2007] Martin Neukom. Ambisonic panning. In 123th Convention of the
     AES, New York, NY, USA, Oct. 5–8, 2007.
 
+.. _dca:
+
+Distance-coded Ambisonics Renderer
+----------------------------------
+
+Executable: ``ssr-dca``
+
+
+Distance-coded Ambisonics (DCA) is sometimes also termed "Nearfield Compensated Higher-Order Ambisonics". This renderer implements the driving functions from [Spors2011]_. The difference to the AAP renderer is a long story, which we will elaborate on at a later point.
+
+Note that the DCA renderer is experimental at this stage. It currently supports orders of up to 28. There are some complications regarding how the user specifies the locations of the loudspeakers and how the renderer handles them. The rendered scene might appear mirrored or rotated. If you are experiencing this, you might want to play around with the assignment of the outputs and the loudspeakers to fix it temporarily. Or contact us.
+
+Please bear with us. We are going to take care of this soon.
+
+.. [Spors2011] S. Spors, V. Kuscher, and J. Ahrens. Efficient Realization of Model-Based Rendering for 2.5-dimensional Near-Field Compensated Higher Order Ambisonics. In IEEE WASPAA, New Paltz, NY, USA, 2011.
+
 .. _genren:
 
 Generic Renderer
 ----------------
+
+Executable: ``ssr-generic``
 
 The generic renderer turns the SSR into a multiple-input-multiple-output
 convolution engine. You have to use an ASDF file in which the attribute

--- a/flext/Makefile
+++ b/flext/Makefile
@@ -5,7 +5,7 @@
 # The flext build system doesn't support compiling multiple externals at once,
 # so we work around this with PD_TARGETS and specify NAME here.
 
-EXTERNALS ?= ssr_binaural ssr_nfc_hoa ssr_aap ssr_wfs ssr_vbap
+EXTERNALS ?= ssr_binaural ssr_dca ssr_aap ssr_wfs ssr_vbap
 
 PD_TARGETS := $(EXTERNALS:%=%_pd)
 

--- a/flext/README.md
+++ b/flext/README.md
@@ -15,7 +15,7 @@ Source positions and other parameters can be controlled by sending messages to
 the leftmost inlet of the external.
 
 Each renderer is available as a separate external, namely
-`ssr_binaural~`, `ssr_nfc_hoa~`, `ssr_aap~`, `ssr_wfs~` and `ssr_vbap~`.
+`ssr_binaural~`, `ssr_dca~`, `ssr_aap~`, `ssr_wfs~` and `ssr_vbap~`.
 
 Requirements
 ------------

--- a/flext/ssr_dca.cpp
+++ b/flext/ssr_dca.cpp
@@ -24,17 +24,12 @@
  * http://spatialaudio.net/ssr                           ssr@spatialaudio.net *
  ******************************************************************************/
 
-// NFC-HOA renderer as MEX file for GNU Octave and MATLAB.
+// DCA renderer as Puredata/Max external.
 
-#include "ssr_mex.h"
-#include "nfchoarenderer.h"
+#include "ssr_flext.h"
+#include "dcarenderer.h"
 
-SsrMex<ssr::NfcHoaRenderer> mexobj;
-
-void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
-{
-  mexobj.mexFunction(nlhs, plhs, nrhs, prhs);
-}
+SSR_FLEXT_INSTANCE(dca, ssr::DcaRenderer)
 
 // Settings for Vim (http://www.vim.org/), please do not remove:
 // vim:softtabstop=2:shiftwidth=2:expandtab:textwidth=80:cindent

--- a/flext/ssr_dca~-help.pd
+++ b/flext/ssr_dca~-help.pd
@@ -6,7 +6,7 @@
 #X obj 165 51 noise~;
 #X obj 30 71 *~ 0.01;
 #X obj 165 73 *~ 0.01;
-#X obj 18 100 ssr_nfc_hoa~ 2 circle.asd;
+#X obj 18 100 ssr_dca~ 2 circle.asd;
 #X text 104 14 <-- open this!;
 #X obj 19 15 ssr_messages;
 #X connect 1 0 3 0;

--- a/flext/virtual_dca.pd
+++ b/flext/virtual_dca.pd
@@ -36,7 +36,7 @@ src 49 pos 0.781832 0.62349 \, src 50 pos 0.707107 0.707107 \, src
 51 pos 0.62349 0.781831 \, src 52 pos 0.532032 0.846724 \, src 53 pos
 0.433884 0.900969 \, src 54 pos 0.330279 0.943883 \, src 55 pos 0.222521
 0.974928 \, src 56 pos 0.111964 0.993712;
-#X obj 18 115 ssr_nfc_hoa~ 2 circle.asd;
+#X obj 18 115 ssr_dca~ 2 circle.asd;
 #X obj 30 71 *~ 0.002;
 #X obj 340 70 *~ 0.001;
 #X connect 0 0 13 0;

--- a/mex/Makefile
+++ b/mex/Makefile
@@ -3,7 +3,7 @@
 # Makefile example:
 # http://www.klab.caltech.edu/~harel/share/gbvs_scale/sift/Makefile
 
-MEXFILES ?= ssr_nfc_hoa ssr_binaural ssr_vbap ssr_aap ssr_wfs ssr_generic \
+MEXFILES ?= ssr_dca ssr_binaural ssr_vbap ssr_aap ssr_wfs ssr_generic \
   ssr_brs
 
 OBJECTS := ssr_global position orientation directionalpoint xmlparser

--- a/mex/README.md
+++ b/mex/README.md
@@ -33,25 +33,25 @@ params.sample_rate = 44100;
 params.reproduction_setup = '../data/reproduction_setups/circle.asd';
 params.threads = 4;
 
-ssr_nfc_hoa('init', sources, params)
+ssr_dca('init', sources, params)
 
 positions = [0; 2];  % one column for each source
 
-ssr_nfc_hoa('source_position', positions)
+ssr_dca('source_position', positions)
 
 % for more parameters see test_ssr.m
 
 % process (and discard) one block for interpolation:
-outputblock = ssr_nfc_hoa('process', single(zeros(params.block_size, sources)));
+outputblock = ssr_dca('process', single(zeros(params.block_size, sources)));
 
 % now the source parameters have reached their desired values
-outputblock = ssr_nfc_hoa('process', inputblock);
+outputblock = ssr_dca('process', inputblock);
 
 % do something with 'outputblock' ...
 % repeat for each block ...
 
-ssr_nfc_hoa out_channels
-ssr_nfc_hoa clear
-ssr_nfc_hoa help
+ssr_dca out_channels
+ssr_dca clear
+ssr_dca help
 
 ```

--- a/mex/ssr_dca.cpp
+++ b/mex/ssr_dca.cpp
@@ -24,12 +24,17 @@
  * http://spatialaudio.net/ssr                           ssr@spatialaudio.net *
  ******************************************************************************/
 
-// NFC-HOA renderer as Puredata/Max external.
+// DCA renderer as MEX file for GNU Octave and MATLAB.
 
-#include "ssr_flext.h"
-#include "nfchoarenderer.h"
+#include "ssr_mex.h"
+#include "dcarenderer.h"
 
-SSR_FLEXT_INSTANCE(nfc_hoa, ssr::NfcHoaRenderer)
+SsrMex<ssr::DcaRenderer> mexobj;
+
+void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
+{
+  mexobj.mexFunction(nlhs, plhs, nrhs, prhs);
+}
 
 // Settings for Vim (http://www.vim.org/), please do not remove:
 // vim:softtabstop=2:shiftwidth=2:expandtab:textwidth=80:cindent

--- a/mex/ssr_helper.m
+++ b/mex/ssr_helper.m
@@ -1,6 +1,6 @@
 function out = ssr_helper(in, func)
 % Run the SSR block-wise on an input signal
-% 'func' is the SSR function, e.g. @ssr_nfc_hoa
+% 'func' is the SSR function, e.g. @ssr_dca
 % 'func' must be initialized already
 
 block_size = func('block_size');

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@
 bin_PROGRAMS = $(SSR_executables)
 
 ## All possible optional programs must be listed here
-EXTRA_PROGRAMS = ssr-binaural ssr-wfs ssr-generic ssr-brs ssr-nfc-hoa ssr-vbap ssr-aap
+EXTRA_PROGRAMS = ssr-binaural ssr-wfs ssr-generic ssr-brs ssr-dca ssr-vbap ssr-aap
 
 ## CPPFLAGS: preprocessor flags, e.g. -I and -D
 ## -I., -I$(srcdir), and a -I pointing to the directory holding config.h
@@ -75,14 +75,14 @@ ssr_brs_SOURCES = ssr_brs.cpp brsrenderer.h \
 
 nodist_ssr_brs_SOURCES = $(SSRMOCFILES)
 
-ssr_nfc_hoa_SOURCES = ssr_nfc_hoa.cpp nfchoarenderer.h \
-	hoacoefficients.h laplace_coeffs_double.h laplace_coeffs_float.h \
+ssr_dca_SOURCES = ssr_dca.cpp dcarenderer.h \
+	dcacoefficients.h laplace_coeffs_double.h laplace_coeffs_float.h \
 	../apf/apf/biquad.h \
 	../apf/apf/denormalprevention.h \
 	$(LOUDSPEAKERSOURCES) \
 	$(SSRSOURCES)
 
-nodist_ssr_nfc_hoa_SOURCES = $(SSRMOCFILES)
+nodist_ssr_dca_SOURCES = $(SSRMOCFILES)
 
 LOUDSPEAKERSOURCES = \
 	loudspeakerrenderer.h \

--- a/src/dcacoefficients.h
+++ b/src/dcacoefficients.h
@@ -25,10 +25,10 @@
  ******************************************************************************/
 
 /// @file
-/// Coefficients for the IIR filters in NfcHoaRenderer
+/// Coefficients for the IIR filters in DcaRenderer
 
-#ifndef SSR_HOACASCADE_H
-#define SSR_HOACASCADE_H
+#ifndef SSR_DCACASCADE_H
+#define SSR_DCACASCADE_H
 
 #include <cmath>  // for std::pow()
 
@@ -56,9 +56,9 @@ const float LaplaceCoeffsBase<float>::laplace_coeffs[][2] = {
 
 }  // namespace internal
 
-/// Coefficients for the IIR filters in NfcHoaRenderer
+/// Coefficients for the IIR filters in DcaRenderer
 template<typename T>
-class HoaCoefficients : public std::vector<apf::SosCoefficients<T>>
+class DcaCoefficients : public std::vector<apf::SosCoefficients<T>>
                       , private internal::LaplaceCoeffsBase<T>
 {
   private:
@@ -69,7 +69,7 @@ class HoaCoefficients : public std::vector<apf::SosCoefficients<T>>
 
     /// Constructor.
     /// @throw std::logic_error if desired order is not supported.
-    HoaCoefficients(size_t order, size_t sample_rate, float array_radius
+    DcaCoefficients(size_t order, size_t sample_rate, float array_radius
         , float speed_of_sound)
       : _base(order == 0 ? 1 : (order + 1) / 2)  // round up
       // calculate starting index to read Laplace-domain coefficients
@@ -83,7 +83,7 @@ class HoaCoefficients : public std::vector<apf::SosCoefficients<T>>
       if (_coeffs_begin
           >= sizeof(this->laplace_coeffs) / sizeof(*this->laplace_coeffs))
       {
-        throw std::logic_error("HoaCoefficients: Order " + apf::str::A2S(order)
+        throw std::logic_error("DcaCoefficients: Order " + apf::str::A2S(order)
             + " is not supported!");
       }
     }
@@ -98,7 +98,7 @@ class HoaCoefficients : public std::vector<apf::SosCoefficients<T>>
       std::copy(iter, iter + this->size(), this->begin());
     }
 
-    void swap(HoaCoefficients& other)
+    void swap(DcaCoefficients& other)
     {
       // TODO: actually swap this stuff?
       assert(_coeffs_begin == other._coeffs_begin);
@@ -110,7 +110,7 @@ class HoaCoefficients : public std::vector<apf::SosCoefficients<T>>
     }
 
     friend std::ostream&
-    operator<<(std::ostream& stream, const HoaCoefficients& c)
+    operator<<(std::ostream& stream, const DcaCoefficients& c)
     {
       std::copy(c.begin(), c.end()
           , std::ostream_iterator<typename _base::value_type>(stream, "\n"));

--- a/src/ssr_dca.cpp
+++ b/src/ssr_dca.cpp
@@ -25,14 +25,14 @@
  ******************************************************************************/
 
 /// @file
-/// Main file for NFC HOA renderer.
+/// Main file for DCA renderer.
 
 #include "controller.h"
-#include "nfchoarenderer.h"
+#include "dcarenderer.h"
 
 int main(int argc, char* argv[])
 {
-  ssr::Controller<ssr::NfcHoaRenderer> controller(argc, argv);
+  ssr::Controller<ssr::DcaRenderer> controller(argc, argv);
 
   controller.run();
 }


### PR DESCRIPTION
The file names still use NFC-HOA, but all user interface related terms have been updated.

This excludes the flext and mex parts for now. The objects are still use NFC-HOA here, too.