### PR TITLE
Drag and drop

### DIFF
--- a/doc/manual/gui.rst
+++ b/doc/manual/gui.rst
@@ -245,6 +245,12 @@ positioning of sources. The properties ``fixed position``, ``muted`` and
 :ref:`4.3 <source_picture>` to see the complete list of properties
 this dialog shows.
 
+Drag & Drop of Scenes
+~~~~~~~~~~~~~~~~~~~~~
+
+You can also drag & drop scenes (or audio files) into the GUI to open them. Currently, you can only drag & drop one single file.
+
+
 .. _keyboard_actions:
 
 Keyboard Actions

--- a/src/gui/qopenglplotter.cpp
+++ b/src/gui/qopenglplotter.cpp
@@ -95,6 +95,7 @@ ssr::QOpenGLPlotter::QOpenGLPlotter(api::Publisher& controller
           Qt::NoModifier)), // dummy event
     _ctrl_pressed(false),
     _alt_pressed(false),
+    _shift_pressed(false),
     _rubber_band_starting_point(Position()),
     _rubber_band_ending_point(Position()),
     _window_x_offset(0.0f),

--- a/src/gui/qopenglplotter.h
+++ b/src/gui/qopenglplotter.h
@@ -153,6 +153,7 @@ class QOpenGLPlotter : public QGLWidget
     QMouseEvent _previous_mouse_event;
     bool   _ctrl_pressed;
     bool   _alt_pressed;
+    bool   _shift_pressed;
 
     int    _find_selected_object(const QPoint &pos);
     void   _get_openGL_pos(int x, int y,

--- a/src/gui/quserinterface.h
+++ b/src/gui/quserinterface.h
@@ -101,6 +101,8 @@ class QUserInterface : public QOpenGLPlotter
     virtual void mouseDoubleClickEvent(QMouseEvent *event);
     virtual void mouseReleaseEvent (QMouseEvent *event);
     virtual void wheelEvent(QWheelEvent * event);
+    virtual void dragEnterEvent(QDragEnterEvent *event);
+    virtual void dropEvent(QDropEvent *event);
 
   private:
     scene_button_list_t _scene_button_list; ///< list which holds all quiack access scene tabs


### PR DESCRIPTION
This enables drag & drop for audio files and scene files into the GUI. This can be handy for quick testing of something. I also changed the signature of the function `load_scene` in ```controller.h```:

https://github.com/SoundScapeRenderer/ssr/commit/74a356aea93bf354923c2b6e765015ec3dc7674b#diff-1f84d7860b51690b2964fd6241a307aaR131

One can now "add" a scene or audio file to an existing one. This can also be handy if one wants to quickly populate a scene without having to write an asd-file.

Questions are:

1) This change of the signature of `load_scene` back propagates into `publisher.h`: https://github.com/SoundScapeRenderer/ssr/commit/74a356aea93bf354923c2b6e765015ec3dc7674b#diff-7fc5376aafac5f57d0519684ea647e06R61
Does this cause any issues?

2) Adding of a scene is enabled by holding the `Shift` key pressed when dragging and dropping. See the [manual](https://github.com/SoundScapeRenderer/ssr/blob/drag-and-drop/doc/manual/gui.rst#drag--drop-of-scenes). [Any other "adding" action](https://github.com/SoundScapeRenderer/ssr/blob/drag-and-drop/doc/manual/gui.rst#keyboard-actions) is currently done through the `Ctrl`key. Unfortunately, this is not possible in the drag & drop case because of possible (or actual) interference with the file browser. Should we change all "adding" action to use the `Shift`key or accept the inconsistency?

