### PR TITLE
Allow sources to be activated/deactivated

### DIFF
--- a/data/websocket_resources/ssr-test-client.html
+++ b/data/websocket_resources/ssr-test-client.html
@@ -126,6 +126,7 @@ function connectWebSocket()
             li.innerHTML =
               `ID: <span class="src-id">${src_id}</span>; ` +
               'name: <span class="src-name">n/a</span>; ' +
+              'active: <span class="src-active">n/a</span>; ' +
               'mute: <span class="src-mute">n/a</span>; ' +
               'model: <span class="src-model">n/a</span>; ' +
               'fixed: <span class="src-fixed">n/a</span><br>' +

--- a/src/api.h
+++ b/src/api.h
@@ -94,6 +94,11 @@ struct SceneControlEvents
   /// @param id ID of the source
   virtual void delete_source(id_t id) = 0;
 
+  /// Activate/deactivate source.
+  /// @param id ID of the source
+  /// @param active activate if @b true, deactivate if @b false
+  virtual void source_active(id_t id, bool active) = 0;
+
   /// Set source position.
   /// @param id ID of the source
   /// @param position new position

--- a/src/controller.h
+++ b/src/controller.h
@@ -959,6 +959,12 @@ public:
     // TODO: stop AudioPlayer if not needed anymore?
   }
 
+  void source_active(id_t id, bool active) override
+  {
+    _controller._publish(_initiator
+        , &api::SceneControlEvents::source_active, id, active);
+  }
+
   void source_position(id_t id, const Pos& position) override
   {
     if (id == "")
@@ -2084,6 +2090,7 @@ Controller<Renderer>::_new_source(id_t requested_id, const std::string& name
   _publish(&api::SceneControlEvents::source_fixed, id, fixed);
   _publish(&api::SceneControlEvents::source_volume, id, volume);
   _publish(&api::SceneControlEvents::source_mute, id, mute);
+  _publish(&api::SceneControlEvents::source_active, id, true);
 }
 
 template<typename Renderer>

--- a/src/legacy_network/networksubscriber.cpp
+++ b/src/legacy_network/networksubscriber.cpp
@@ -73,6 +73,12 @@ NetworkSubscriber::delete_source(id_t id)
       "<update><delete><source id='", id, "' /></delete></update>");
 }
 
+void
+NetworkSubscriber::source_active(id_t id, bool active)
+{
+  (void)active;
+  // not implemented
+}
 
 void
 NetworkSubscriber::source_position(id_t id, const Pos& pos)

--- a/src/legacy_network/networksubscriber.h
+++ b/src/legacy_network/networksubscriber.h
@@ -62,6 +62,7 @@ class NetworkSubscriber : public api::SceneControlEvents
 
     void auto_rotate_sources(bool) override {}
     void delete_source(id_t id) override;
+    void source_active(id_t id, bool active) override;
     void source_position(id_t id, const Pos& position) override;
     void source_rotation(id_t id, const Rot& rotation) override;
     void source_volume(id_t id, float gain) override;

--- a/src/legacy_scene.h
+++ b/src/legacy_scene.h
@@ -264,6 +264,11 @@ class LegacyScene : public api::SceneControlEvents
       }
     }
 
+    void source_active(id_t id, bool active) override
+    {
+      _set_source_member(id, &LegacySource::active, active);
+    }
+
     void source_position(id_t id, const Pos& position) override
     {
       _set_source_member(id, &LegacySource::position, position);

--- a/src/legacy_source.h
+++ b/src/legacy_source.h
@@ -60,6 +60,7 @@ struct LegacySource : DirectionalPoint
       const Position&    position    = Position(),
       const Orientation& orientation = Orientation()) :
     DirectionalPoint(position, orientation), // base class ctor
+    active(0),
     audio_file_channel(0),
     file_length(0),
     model(LegacySource::point),
@@ -78,6 +79,7 @@ struct LegacySource : DirectionalPoint
       const Position&    position    = Position(),
       const Orientation& orientation = Orientation()) :
     DirectionalPoint(position, orientation), // base class ctor
+    active(0),
     audio_file_channel(0),
     file_length(0),
     model(LegacySource::point),
@@ -90,6 +92,7 @@ struct LegacySource : DirectionalPoint
     doppler_effect(false)
   {}
 
+  bool active;
   std::string name;               ///< source name
   std::string audio_file_name;    ///< audio file
   int audio_file_channel;         ///< channel of audio file

--- a/src/rendererbase.h
+++ b/src/rendererbase.h
@@ -398,6 +398,7 @@ class RendererBase<Derived>::Source
     explicit Source(const Params& p)
       : parent(*(p.parent ? p.parent : throw std::logic_error(
               "Bug (RendererBase::Source): parent == NULL!")))
+      , active(*p.fifo, false)
       , position(*(p.fifo ? p.fifo : throw std::logic_error(
               "Bug (RendererBase::Source): fifo == NULL!")))
       , rotation(*p.fifo)
@@ -427,6 +428,7 @@ class RendererBase<Derived>::Source
 
     Derived& parent;
 
+    apf::SharedData<bool> active;
     apf::SharedData<Pos> position;
     apf::SharedData<Rot> rotation;
     apf::SharedData<sample_type> gain;
@@ -462,7 +464,7 @@ void RendererBase<Derived>::Source::_process()
   this->_begin = _input.begin();
   this->_end = _input.end();
 
-  if (!this->parent.state.processing || this->mute)
+  if (!this->parent.state.processing || this->mute || !this->active)
   {
     this->weighting_factor = 0.0;
   }

--- a/src/rendersubscriber.h
+++ b/src/rendersubscriber.h
@@ -102,6 +102,11 @@ private:
     _renderer.rem_source(id);
   }
 
+  void source_active(id_t id, bool active) override
+  {
+    _set_source_member(id, &Source::active, active);
+  }
+
   void source_position(id_t id, const Pos& pos) override
   {
     _set_source_member(id, &Source::position, pos);

--- a/src/scene.h
+++ b/src/scene.h
@@ -48,6 +48,8 @@ class Scene : public api::SceneControlEvents
 public:
   struct Source
   {
+    bool active{false};
+
     Pos position{};
     Rot rotation{};
     bool fixed{false};  ///< Static position/rotation or not
@@ -112,6 +114,7 @@ public:
     subscriber->amplitude_reference_distance(_amplitude_reference_distance);
 
     this->for_each_source([subscriber](auto id, auto& source) {
+        subscriber->source_active(id, source.active);
         subscriber->source_position(id, source.position);
         subscriber->source_rotation(id, source.rotation);
         subscriber->source_volume(id, source.volume);
@@ -170,6 +173,11 @@ private:
     {
       _source_ids.erase(std::find(_source_ids.begin(), _source_ids.end(), id));
     }
+  }
+
+  void source_active(id_t id, bool active) override
+  {
+    _set_source_member(id, &Source::active, active);
   }
 
   void source_position(id_t id, const Pos& position) override

--- a/src/websocket/connection.h
+++ b/src/websocket/connection.h
@@ -203,6 +203,11 @@ private:
     _delete_source.PushBack(json::Value{id, _out_allocator}, _out_allocator);
   }
 
+  void source_active(id_t id, bool active) override
+  {
+    _set_source_property(id, "active", active);
+  }
+
   void source_position(id_t id, const Pos& position) override
   {
     _set_source_property(id, "pos", _to_list(position));
@@ -991,7 +996,16 @@ Connection::on_message(message_ptr msg)
         for (const auto& attr: source.value.GetObject())
         {
           // source-related SceneControlEvents (except delete_source)
-          if (attr.name == "pos")
+          if (attr.name == "active")
+          {
+            if (!attr.value.IsBool())
+            {
+              SSR_ERROR("Invalid source active state: " << attr.value);
+              return;
+            }
+            control->source_active(id, attr.value.GetBool());
+          }
+          else if (attr.name == "pos")
           {
             auto pos = internal::parse_position(attr.value);
             if (!pos) { return; }


### PR DESCRIPTION
Currently, this feature is not used yet.

But it will be used by a future PR about dynamic sources.

The browser client changes the visibility of sources according to their "active" state (this was already implemented before).

The legacy Qt GUI ignores the property for now (inactive sources are shown the same way as active sources).