### PR TITLE
Support for dynamic ASDF scenes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
     environment:
       PIP_INSTALL: python -m pip install --progress-bar off --upgrade
-      CONFIGURE_FLAGS: --disable-ecasound --disable-gui --disable-ip-interface --disable-websocket-interface --disable-fudi-interface --enable-browser-gui
+      CONFIGURE_FLAGS: --disable-ecasound --disable-dynamic-asdf --disable-gui --disable-ip-interface --disable-websocket-interface --disable-fudi-interface --enable-browser-gui
 
     steps:
       - checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:
-      - name: Clone Git repo
+      - name: Clone SSR repo
         uses: actions/checkout@v3
         with:
           submodules: true
@@ -128,12 +128,30 @@ jobs:
         run: |
           sudo cp SDK/MacOSX/Sample/*.h /usr/local/include
           sudo cp SDK/MacOSX/UniversalLib/libisense.dylib /usr/local/lib
+      - name: Install cargo-c
+        run: |
+          cargo install cargo-c --force
+      - name: Clone ASDF repo
+        uses: actions/checkout@v3
+        with:
+          repository:  AudioSceneDescriptionFormat/asdf-rust
+          submodules: true
+          path: asdf-rust
+      - name: Build and install ASDF library
+        working-directory: asdf-rust
+        run: |
+          cargo cinstall --release --prefix=/usr/local --destdir=temp
+          sudo cp -r temp/usr/local/* /usr/local/
+      - name: Update dynamic linker cache for libasdf
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo ldconfig
       - run: |
           ./autogen.sh
       - name: configure
         # NB: browser-gui is tested with CircleCI
         run: |
-          ./configure --enable-gui --enable-ip-interface --enable-websocket-interface --enable-fudi-interface --enable-ecasound --enable-sofa --enable-polhemus --enable-razor --enable-vrpn --enable-intersense --disable-browser-gui --disable-dependency-tracking
+          ./configure --enable-gui --enable-ip-interface --enable-websocket-interface --enable-fudi-interface --enable-ecasound --enable-sofa --enable-polhemus --enable-razor --enable-vrpn --enable-intersense --disable-browser-gui --enable-dynamic-asdf --disable-dependency-tracking
       - name: upload config.log
         if: failure()
         uses: actions/upload-artifact@v3

--- a/configure.ac
+++ b/configure.ac
@@ -596,6 +596,13 @@ ENABLE_AUTO([sofa], [SOFA support for binaural renderer],
   AC_SEARCH_LIBS([mysofa_open], [mysofa], , [have_sofa=no])
 ])
 
+ENABLE_FORCED([dynamic-asdf], [dynamic ASDF scenes],
+[
+  PKG_CHECK_MODULES([ASDF], [asdf], , [have_dynamic_asdf=no])
+  PKG_FLAGS="$PKG_FLAGS $ASDF_CFLAGS"
+  LIBS="$LIBS $ASDF_LIBS"
+])
+
 dnl Checking for Polhemus Fastrak/Patriot support
 ENABLE_AUTO([polhemus], [Polhemus Fastrak/Patriot tracker support],
 [
@@ -789,7 +796,6 @@ AS_IF([test x$have_intersense = xyes],
     [intersense_version="version < 4.04"]),
   [intersense_version=no])
 
-echo "|"
 echo "| Build with tracker support:"
 echo "|    InterSense .......................... : $intersense_version"
 echo "|    Polhemus Fastrak/Patriot ............ : $have_polhemus"
@@ -797,6 +803,7 @@ echo "|    Razor AHRS .......................... : $have_razor"
 echo "|    VRPN ................................ : $have_vrpn"
 echo "|"
 echo "| Ecasound/SOFA support .................. : $have_ecasound/$have_sofa"
+echo "| Dynamic ASDF scenes .................... : $have_dynamic_asdf"
 echo "| Network: legacy/WebSocket/FUDI ......... : $have_ip_interface/$have_websocket_interface/$have_fudi_interface"
 echo "| Qt GUI/Browser GUI ..................... : $have_gui/$have_browser_gui"
 echo "|"
@@ -816,7 +823,6 @@ AS_IF([test x$have_manpages != xyes],
   echo "|>  Disabling building of manpages"
 ])
 
-echo "|"
 echo
 echo 'If everything looks OK, continue with "make" and "make install".'
 echo

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -148,6 +148,10 @@ SSRSOURCES = \
 	xmlparser.h \
 	rendersubscriber.h
 
+if ENABLE_DYNAMIC_ASDF
+SSRSOURCES += dynamic_scene.h
+endif
+
 if ENABLE_INTERSENSE
 SSRSOURCES += trackerintersense.cpp trackerintersense.h
 endif

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -621,8 +621,13 @@ ssr::conf_struct ssr::configuration(int& argc, char* argv[])
 
   conf.renderer_params.set("xml_schema", conf.xml_schema);
 
-  if (!conf.freewheeling)
+  if (conf.freewheeling)
   {
+    conf.renderer_params.set("freewheeling", true);
+  }
+  else
+  {
+    conf.renderer_params.set("freewheeling", false);
     conf.renderer_params.set("system_output_prefix", conf.output_port_prefix);
   }
 

--- a/src/dynamic_scene.h
+++ b/src/dynamic_scene.h
@@ -1,0 +1,166 @@
+/******************************************************************************
+ * Copyright © 2019 SSR Contributors                                          *
+ *                                                                            *
+ * This file is part of the SoundScape Renderer (SSR).                        *
+ *                                                                            *
+ * The SSR is free software:  you can redistribute it and/or modify it  under *
+ * the terms of the  GNU  General  Public  License  as published by the  Free *
+ * Software Foundation, either version 3 of the License,  or (at your option) *
+ * any later version.                                                         *
+ *                                                                            *
+ * The SSR is distributed in the hope that it will be useful, but WITHOUT ANY *
+ * WARRANTY;  without even the implied warranty of MERCHANTABILITY or FITNESS *
+ * FOR A PARTICULAR PURPOSE.                                                  *
+ * See the GNU General Public License for more details.                       *
+ *                                                                            *
+ * You should  have received a copy  of the GNU General Public License  along *
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.            *
+ *                                                                            *
+ * The SSR is a tool  for  real-time  spatial audio reproduction  providing a *
+ * variety of rendering algorithms.                                           *
+ *                                                                            *
+ * http://spatialaudio.net/ssr                           ssr@spatialaudio.net *
+ ******************************************************************************/
+
+/// @file
+/// Dynamic scene loaded from ASDF file.
+
+#ifndef SSR_DYNAMIC_SCENE_H
+#define SSR_DYNAMIC_SCENE_H
+
+#include <vector>
+
+#include <asdf.h>
+#include "geometry.h"
+
+namespace ssr
+{
+
+using frame_count_t = uint64_t;
+
+struct DynamicSourceInfo
+{
+  std::string id;
+  std::string name;
+  std::string model;
+  std::string port;
+};
+
+struct Transform
+{
+  quat rot;
+  vec3 pos;
+  float vol;
+
+  Transform()
+    : rot{0.0f, {1.0f, 0.0f, 0.0f}}
+    , pos{}
+    , vol{1.0f}
+  {}
+
+  Transform(const AsdfTransform& t)
+    : rot{t.rot_s, vec3{t.rot_v[0], t.rot_v[1], t.rot_v[2]}}
+    , pos{t.pos[0], t.pos[1], t.pos[2]}
+    , vol{t.vol}
+  {}
+};
+
+class DynamicScene
+{
+public:
+  // TODO: pass input prefix for live sources?
+  DynamicScene(const std::string& scene_file_name, uint32_t samplerate
+      , uint32_t blocksize, uint32_t buffer_blocks, uint64_t usleeptime)
+    : _ptr(asdf_scene_new(
+          scene_file_name.c_str(), samplerate, blocksize, buffer_blocks,
+          usleeptime))
+  {
+    if (!_ptr) {
+      throw std::runtime_error(asdf_last_error());
+    }
+    auto file_sources = this->file_sources();
+    _audio_data.resize(file_sources * blocksize);
+    for (size_t i = 0; i < file_sources; ++i)
+    {
+      _file_source_ptrs.push_back(_audio_data.data() + i * blocksize);
+    }
+  }
+
+  ~DynamicScene()
+  {
+    asdf_scene_free(_ptr);
+  }
+
+  size_t file_sources() const
+  {
+    return asdf_file_sources(_ptr);
+  }
+
+  size_t live_sources() const
+  {
+    return asdf_live_sources(_ptr);
+  }
+
+  DynamicSourceInfo get_sourceinfo(size_t index) const {
+    assert(_ptr);
+    auto* source = asdf_get_sourceinfo(_ptr, index);
+    if (source == nullptr)
+    {
+      throw std::runtime_error(asdf_last_error());
+    }
+    DynamicSourceInfo result{source->id, source->name, source->model
+      , source->port};
+    asdf_sourceinfo_free(source);
+    return result;
+  }
+
+  const float* file_source_ptr(size_t index) const
+  {
+    return _file_source_ptrs[index];
+  }
+
+  bool seek(size_t frame)
+  {
+    assert(_ptr);
+    return asdf_seek(_ptr, frame);
+  }
+
+  AsdfStreamingResult update_audio_data(bool rolling)
+  {
+    assert(_ptr);
+    // NB: if there are no file sources, data() may return NULL.
+    return asdf_get_audio_data(_ptr, _file_source_ptrs.data(), rolling);
+  }
+
+  /// This is realtime-safe
+  /// source_number is 0-based
+  std::optional<Transform>
+  get_source_transform(size_t source_idx, frame_count_t frame) const
+  {
+    assert(_ptr);
+    auto t = asdf_get_source_transform(_ptr, source_idx, frame);
+    std::optional<Transform> result{};
+    if (t.active)
+    {
+      result = Transform{t};
+    }
+    return result;
+  }
+
+  Transform get_reference_transform(frame_count_t frame) const
+  {
+    assert(_ptr);
+    auto t = asdf_get_reference_transform(_ptr, frame);
+    assert(t.active);
+    return {t};
+  }
+
+private:
+  AsdfScene* _ptr;
+  std::vector<float> _audio_data;
+  std::vector<float*> _file_source_ptrs;
+};
+
+}  // namespace ssr
+
+#endif

--- a/src/rendererbase.h
+++ b/src/rendererbase.h
@@ -42,6 +42,10 @@
 #include "maptools.h"
 #include "geometry.h"  // for vec3
 
+#ifdef ENABLE_DYNAMIC_ASDF
+#include "dynamic_scene.h"
+#endif
+
 #ifndef SSR_QUERY_POLICY
 #define SSR_QUERY_POLICY apf::disable_queries
 #endif
@@ -156,6 +160,14 @@ class RendererBase : public apf::MimoProcessor<Derived
         DataMember _member;
     };
 
+#ifdef ENABLE_DYNAMIC_ASDF
+    struct Process;
+
+    std::vector<DynamicSourceInfo>
+    load_dynamic_scene(const std::string& scene_file_name
+        , const std::string& input_port_prefix);
+#endif
+
     template<typename L, typename ListProxy, typename DataMember>
     void add_to_sublist(const L& input, ListProxy output, DataMember member)
     {
@@ -199,7 +211,8 @@ class RendererBase : public apf::MimoProcessor<Derived
     }
 
     std::string add_source(id_t id
-        , const apf::parameter_map& p = apf::parameter_map());
+        , const apf::parameter_map& p = apf::parameter_map()
+        , const float* file_source_ptr = nullptr);
     void rem_source(id_t id);
     void rem_all_sources();
 
@@ -217,6 +230,16 @@ class RendererBase : public apf::MimoProcessor<Derived
     auto get_scoped_lock() { return std::make_unique<ScopedLock>(_lock); }
 
     const sample_type master_volume_correction;  // linear
+
+#ifdef ENABLE_DYNAMIC_ASDF
+    using dynamic_source_list_t = std::vector<std::optional<ssr::Transform>>;
+    // NB: It's probably not a good idea to make this public:
+    apf::SharedData<std::unique_ptr<dynamic_source_list_t>> dynamic_sources;
+    // NB: This is only ever accessed from the realtime thread:
+    Transform dynamic_reference{};
+
+    bool freewheeling;
+#endif
 
   protected:
     RendererBase(const apf::parameter_map& p);
@@ -242,6 +265,21 @@ class RendererBase : public apf::MimoProcessor<Derived
     size_t _next_id_suffix = 0;
 
     std::mutex _lock;
+
+#ifdef ENABLE_DYNAMIC_ASDF
+    int jack_sync_callback(jack_transport_state_t
+        , jack_position_t *pos) override
+    {
+      if (_scene == nullptr)
+      {
+        return 1;
+      }
+      return _scene.get()->seek(pos->frame);
+    }
+
+    apf::SharedData<std::unique_ptr<DynamicScene>> _scene;
+    uint64_t usleeptime;
+#endif
 };
 
 /** Constructor.
@@ -253,9 +291,16 @@ RendererBase<Derived>::RendererBase(const apf::parameter_map& p)
   , state(_fifo, p)
   , master_volume_correction(apf::math::dB2linear(
         this->params.get("master_volume_correction", 0.0)))
+#ifdef ENABLE_DYNAMIC_ASDF
+  , dynamic_sources(_fifo)
+  , freewheeling(this->params.get("freewheeling", false))
+#endif
   , _master_level()
   , _source_list(_fifo)
   , _show_head(true)
+#ifdef ENABLE_DYNAMIC_ASDF
+  , _scene(_fifo)
+#endif
 {}
 
 /** Create a new source.
@@ -265,7 +310,7 @@ RendererBase<Derived>::RendererBase(const apf::parameter_map& p)
 template<typename Derived>
 std::string
 RendererBase<Derived>::add_source(id_t requested_id
-    , const apf::parameter_map& p)
+    , const apf::parameter_map& p, const float* file_source_ptr)
 {
   std::string id = requested_id;
   if (id.size() && _source_map.find(id) != _source_map.end())
@@ -281,29 +326,41 @@ RendererBase<Derived>::add_source(id_t requested_id
     while (_source_map.find(id) != _source_map.end());
   }
 
-  typename Derived::Input::Params in_params;
-  in_params = p;
-  auto in = this->add(in_params);
-
-  // WARNING: if Derived::Input throws an exception, the SSR crashes!
-
   typename Derived::Source::Params src_params;
   src_params = p;
   src_params.parent = &this->derived();
   src_params.fifo = &_fifo;
-  src_params.input = in;
   src_params.id = id;
 
-  typename Derived::Source* src;
+  if (file_source_ptr == nullptr)
+  {
+    typename Derived::Input::Params in_params;
+    in_params = p;
+    auto in = this->add(in_params);
+    // WARNING: if Derived::Input throws an exception, the SSR crashes!
+    src_params.input = in;
+  }
+  else
+  {
+#ifdef ENABLE_DYNAMIC_ASDF
+    src_params.file_source_ptr = file_source_ptr;
+#else
+    assert(false);
+#endif
+  }
 
+  typename Derived::Source* src;
   try
   {
     src = _source_list.add(new typename Derived::Source(src_params));
   }
   catch (...)
   {
-    // TODO: really remove the corresponding Input?
-    this->rem(in);
+    if (src_params.input)
+    {
+      auto* input = const_cast<typename Derived::Input*>(src_params.input);
+      this->rem(input);
+    }
     throw;
   }
 
@@ -334,13 +391,16 @@ void RendererBase<Derived>::rem_source(id_t id)
   assert(source);
   source->derived().disconnect();
 
-  auto input = const_cast<typename Derived::Input*>(&source->_input);
+  auto* input = const_cast<typename Derived::Input*>(source->_input);
   _source_list.rem(source);
 
   // TODO: really remove the corresponding Input?
   // ATTENTION: there may be several sources using the input! (or not?)
 
-  this->rem(input);
+  if (input != nullptr)
+  {
+    this->rem(input);
+  }
 }
 
 template<typename Derived>
@@ -368,6 +428,220 @@ RendererBase<Derived>::get_source(id_t id)
   }
 }
 
+
+#ifdef ENABLE_DYNAMIC_ASDF
+// NB: The APF_PROCESS macro doesn't work here because of the use of CRTP.
+template<typename Derived>
+struct RendererBase<Derived>::Process : _base::Process
+{
+  Process(Derived& parent)
+    : _base::Process(parent)
+  {
+    const auto& scene = parent._scene.get();
+    if (!scene) return;
+
+    assert(parent.dynamic_sources != nullptr);
+    auto& source_list = *parent.dynamic_sources.get();
+    assert(source_list.size() == scene->file_sources() + scene->live_sources());
+
+    auto [rolling, transport_frame] = parent.get_transport_state();
+
+    while (true)
+    {
+      auto result = scene->update_audio_data(rolling);
+      if (result == ASDF_STREAMING_SUCCESS)
+      {
+        break;
+      }
+      else if (result == ASDF_STREAMING_EMPTY_BUFFER)
+      {
+        if (parent.freewheeling)
+        {
+          // Do nothing, just try again later ...
+        }
+        else
+        {
+          SSR_ERROR("ASDF streaming: empty buffer");
+          throw std::runtime_error("exiting callback");
+        }
+      }
+      else if (result == ASDF_STREAMING_INCOMPLETE_SEEK)
+      {
+        SSR_ERROR("Bug: incomplete seek");
+        throw std::runtime_error("exiting callback");
+      }
+      else if (result == ASDF_STREAMING_SEEK_WHILE_ROLLING)
+      {
+        SSR_ERROR("Bug: seek while rolling");
+        throw std::runtime_error("exiting callback");
+      }
+      else
+      {
+        assert(false);
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(parent.usleeptime));
+    }
+
+    {
+      auto t = scene->get_reference_transform(transport_frame);
+      auto rotation = t.rot;
+      if (rotation != parent.dynamic_reference.rot) {
+        parent.dynamic_reference.rot = rotation;
+        parent.state.reference_rotation.set_from_rt_thread(rotation);
+      }
+      auto position = t.pos;
+      if (position != parent.dynamic_reference.pos) {
+        parent.dynamic_reference.pos = position;
+        parent.state.reference_position.set_from_rt_thread(position);
+      }
+      auto volume = t.vol;
+      if (volume != parent.dynamic_reference.vol) {
+        parent.dynamic_reference.vol = volume;
+        parent.state.master_volume.set_from_rt_thread(std::move(volume));
+      }
+    }
+
+    // NB: Functions for checking dynamic sources are not thread safe,
+    //     therefore we call them in a loop from a single thread.
+
+    for (auto& source: apf::cast_proxy<typename Derived::Source, rtlist_t>(
+          parent._source_list))
+    {
+      size_t source_number = source.dynamic_number;
+      if (source_number == static_cast<size_t>(-1))
+      {
+        continue;  // This source is not part of the dynamic ASDF scene
+      }
+      auto transform = scene->get_source_transform(
+          source_number, transport_frame);
+      auto& target_transform = source_list[source_number];
+      if (transform)
+      {
+        if (target_transform == std::nullopt)
+        {
+          source.active.set_from_rt_thread(true);
+          target_transform = ssr::Transform{};
+        }
+
+        auto rotation = transform->rot;
+        if (rotation != target_transform->rot)
+        {
+          target_transform->rot = rotation;
+          source.rotation.set_from_rt_thread(rotation);
+        }
+
+        auto position = transform->pos;
+        if (position != target_transform->pos)
+        {
+          target_transform->pos = position;
+          source.position.set_from_rt_thread(position);
+        }
+
+        auto volume = transform->vol;
+        if (volume != target_transform->vol)
+        {
+          target_transform->vol = volume;
+          source.gain.set_from_rt_thread(std::move(volume));
+        }
+      }
+      else
+      {
+        if (target_transform)
+        {
+          source.active.set_from_rt_thread(false);
+        }
+        target_transform = std::nullopt;
+      }
+    }
+  }
+};
+
+
+/// This has to be called while the controller lock is held.
+/// All existing sources must be removed before calling this.
+template<typename Derived>
+std::vector<DynamicSourceInfo>
+RendererBase<Derived>::load_dynamic_scene(const std::string& scene_file_name
+    , const std::string& input_port_prefix)
+{
+  assert(_source_map.empty());
+
+  // NB: This is important because the audio thread checks _scene first
+  _scene = nullptr;
+
+  // Wait for sources to be deleted, to avoid source ID clashes with new ones.
+  // Also, make sure the audio thread runs at least once with an empty scene.
+  this->wait_for_rt_thread();
+
+  // TODO: make configuration option!
+  float buffer_time = 2.0;  // seconds, will be rounded up to JACK block size increments
+  float sleep_time = 0.1;  // seconds
+  uint32_t buffer_blocks = std::ceil(buffer_time * this->sample_rate() /
+    this->block_size());
+  this->usleeptime = sleep_time * 1000.0f * 1000.0f;
+  auto scene = std::make_unique<DynamicScene>(
+      scene_file_name, this->sample_rate(), this->block_size(),
+      buffer_blocks, this->usleeptime);
+
+  auto file_sources = scene->file_sources();
+  auto live_sources = scene->live_sources();
+  auto total_sources = file_sources + live_sources;
+
+  // TODO: different way to store list of dynamic sources?
+
+  // TODO: extend with "state" information?
+  this->dynamic_sources = std::make_unique<dynamic_source_list_t>(
+      total_sources);
+
+  // TODO: reset "state buffer"?
+
+  std::vector<DynamicSourceInfo> sources;
+  sources.reserve(total_sources);
+
+  for (size_t i = 0; i < total_sources; i++)
+  {
+    apf::parameter_map p;
+    auto source = scene->get_sourceinfo(i);
+
+    // TODO:
+    //p.set("properties-file", ???);
+
+    const float* file_source_ptr = nullptr;
+    if (i < file_sources)
+    {
+      file_source_ptr = scene->file_source_ptr(i);
+    }
+    else
+    {
+      assert(file_source_ptr == nullptr);  // A JACK port will be created
+      p.set("connect-to", input_port_prefix + source.port);
+    }
+
+    p.set("dynamic-number", i);
+
+    try
+    {
+      auto id = this->add_source(source.id, p, file_source_ptr);
+      assert(source.id == "" || id == source.id);  // IDs must be unique
+      assert(id != "");
+      source.id = id;
+    }
+    catch (std::exception& e)
+    {
+      this->rem_all_sources();
+      throw;
+    }
+    sources.push_back(std::move(source));
+  }
+  SSR_VERBOSE("Loaded scene with "
+      << file_sources << " file source(s) and "
+      << live_sources << " live source(s).");
+  _scene = std::move(scene);
+  return sources;
+}
+#endif
+
+
 /// A sound source.
 template<typename Derived>
 class RendererBase<Derived>::Source
@@ -381,6 +655,10 @@ class RendererBase<Derived>::Source
   public:
     using sample_type
       = typename std::iterator_traits<typename Input::iterator>::value_type;
+#ifdef ENABLE_DYNAMIC_ASDF
+    // dynamic scenes only support float
+    static_assert(std::is_same_v<sample_type, float>);
+#endif
 
     friend class RendererBase<Derived>;  // rem_source() needs access to _input
 
@@ -388,6 +666,9 @@ class RendererBase<Derived>::Source
     {
       Derived* parent = nullptr;
       const typename Derived::Input* input = nullptr;
+#ifdef ENABLE_DYNAMIC_ASDF
+      const float* file_source_ptr = nullptr;
+#endif
       apf::CommandQueue* fifo = nullptr;
       std::string id;
 
@@ -406,11 +687,32 @@ class RendererBase<Derived>::Source
       , model(*p.fifo, "point")
       , weighting_factor()
       , id(p.id)
-      , _input(*(p.input ? p.input : throw std::logic_error(
-              "Bug (RendererBase::Source): input == NULL!")))
+#ifdef ENABLE_DYNAMIC_ASDF
+      , dynamic_number(p.template get<size_t>("dynamic-number", -1))
+#endif
+      , _input(p.input)
       , _pre_fader_level()
       , _level()
-    {}
+    {
+#ifdef ENABLE_DYNAMIC_ASDF
+      if (p.input == nullptr)
+      {
+        if (p.file_source_ptr == nullptr)
+        {
+          throw std::logic_error("Bug (RendererBase::Source): input == NULL "
+              "&& file_source_ptr == NULL!");
+        }
+        static_assert(std::is_same_v<typename Input::iterator, const float*>);
+        this->_begin = p.file_source_ptr;
+        this->_end = p.file_source_ptr + this->parent.block_size();
+      }
+#else
+      if (p.input == nullptr)
+      {
+        throw std::logic_error("Bug (RendererBase::Source): input == NULL!");
+      }
+#endif
+    }
 
     APF_PROCESS(Source, SourceBase)
     {
@@ -421,6 +723,18 @@ class RendererBase<Derived>::Source
 
     // In the default case, the output levels are ignored
     bool get_output_levels(sample_type*, sample_type*) const { return false; }
+
+    std::string port_name() const
+    {
+      if (_input == nullptr)
+      {
+        return "";
+      }
+      else
+      {
+        return _input->port_name();
+      }
+    }
 
     void connect() {}
     void disconnect() {}
@@ -437,9 +751,12 @@ class RendererBase<Derived>::Source
     apf::BlockParameter<sample_type> weighting_factor;
 
     const std::string id;
+#ifdef ENABLE_DYNAMIC_ASDF
+    const size_t dynamic_number;
+#endif
 
   protected:
-    const typename Derived::Input& _input;
+    const typename Derived::Input* _input;
 
   private:
     void _process();
@@ -460,8 +777,20 @@ class RendererBase<Derived>::Source
 template<typename Derived>
 void RendererBase<Derived>::Source::_process()
 {
-  this->_begin = _input.begin();
-  this->_end = _input.end();
+#ifdef ENABLE_DYNAMIC_ASDF
+  if (_input == nullptr)
+  {
+    // NB: _begin and _end were initialized in the constructor.
+  }
+  else
+  {
+#endif
+    assert(_input != nullptr);
+    this->_begin = _input->begin();
+    this->_end = _input->end();
+#ifdef ENABLE_DYNAMIC_ASDF
+  }
+#endif
 
   if (!this->parent.state.processing || this->mute || !this->active)
   {


### PR DESCRIPTION
This is an incomplete implementation of the still very incomplete dynamic ASDF.

(Incomplete) documentation of the ASDF can be found at https://audioscenedescriptionformat.readthedocs.io/

To compile this, the ASDF library has to be installed, see https://github.com/AudioSceneDescriptionFormat/asdf-rust#building-the-c-api

The new ASDF library does *not* depend on Ecasound, therefore it might even be possible to compile it on Windows (but I didn't try).

Support for the dynamic ASDF is completely optional, it can be disabled with

    ./configure --disable-dynamic-asdf