### PR TITLE
add a small type check in command `mod-src` of websocket interface

### DIFF
--- a/src/websocket/connection.h
+++ b/src/websocket/connection.h
@@ -980,6 +980,12 @@ Connection::on_message(message_ptr msg)
     }
     else if (command == "mod-src")
     {
+      if (!value.IsObject())
+      {
+        SSR_ERROR("Expected JSON object, not " << value);
+        return;
+      }
+      
       if (!control)
       {
         control = _controller.take_control();


### PR DESCRIPTION
I have been reading the source code of ssr recently. I found a small code defect in websocket interface part. And I just added a simple type check to fix it.