### PR TITLE
Add SOFA support to binaural renderer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - jackd1
       - pkg-config
       - libtool
+      - libmysofa-dev
   homebrew:
     update: true
     packages:
@@ -37,6 +38,8 @@ addons:
       - libsndfile
       - libxml2
       - qt
+      # libmysofa needs this:
+      - cunit
       # using brew, it's not possible to install needed perl dependencies for
       # help2man (Locale::gettext), therefore best disabled for now
       #- help2man

--- a/apf/apf/mimoprocessor.h
+++ b/apf/apf/mimoprocessor.h
@@ -332,6 +332,9 @@ class MimoProcessor : public interface_policy
     const rtlist_t& get_input_list() const { return _input_list; }
     const rtlist_t& get_output_list() const { return _output_list; }
 
+    unsigned threads() const { return _num_threads; }
+
+    // TODO: make private?
     const parameter_map params;
 
   protected:

--- a/ci/build-deps.sh
+++ b/ci/build-deps.sh
@@ -13,6 +13,15 @@ then
   sudo make install
   cd ..
   cd ..
+
+  git clone git://github.com/hoene/libmysofa.git
+  cd libmysofa
+  cd build
+  cmake -DCMAKE_BUILD_TYPE=Debug ..
+  make
+  sudo make install
+  cd ..
+  cd ..
 fi
 
 if [ "$TRAVIS_OS_NAME" = linux ]

--- a/configure.ac
+++ b/configure.ac
@@ -570,6 +570,12 @@ AS_IF([test x$have_ecasound != xno],
   AC_CHECK_PROG([have_ecasound_program], [ecasound], [yes], [no])
 ])
 
+ENABLE_AUTO([sofa], [SOFA support for binaural renderer],
+[
+  AC_CHECK_HEADER([mysofa.h], , [have_sofa=no])
+  AC_SEARCH_LIBS([mysofa_open], [mysofa], , [have_sofa=no])
+])
+
 dnl Checking for Polhemus Fastrak/Patriot support
 ENABLE_AUTO([polhemus], [Polhemus Fastrak/Patriot tracker support],
 [
@@ -782,7 +788,7 @@ echo "|    Polhemus Fastrak/Patriot ............ : $have_polhemus"
 echo "|    Razor AHRS .......................... : $have_razor"
 echo "|    VRPN ................................ : $have_vrpn"
 echo "|"
-echo "| Build with Ecasound support ............ : $have_ecasound"
+echo "| Ecasound/SOFA support .................. : $have_ecasound/$have_sofa"
 echo "| Network: legacy/WebSocket .............. : $have_ip_interface/$have_websocket_interface"
 echo "| Build with GUI ......................... : $gui_string"
 echo "|"

--- a/src/binauralrenderer.h
+++ b/src/binauralrenderer.h
@@ -209,6 +209,11 @@ BinauralRenderer::_load_wav(const std::string& filename, size_t size)
 void
 BinauralRenderer::_load_sofa(const std::string& filename, size_t size)
 {
+  if (this->threads() != 1)
+  {
+    throw std::logic_error(
+        "SOFA files cannot be used with multiple threads (for now)");
+  }
   int err;
   auto hrir_file = std::unique_ptr<MYSOFA_HRTF, decltype(&mysofa_free)>{
     mysofa_load(filename.c_str(), &err),


### PR DESCRIPTION
This uses https://github.com/hoene/libmysofa for loading SOFA files.

Currently, this only works when using a single audio thread (e.g. using the command-line option `--threads=1`).
I hope to find a quick solution to enable multiple threads, see also https://github.com/hoene/libmysofa/issues/80.

SOFA files with delays are not supported. I think it would be quite a lot of work to implement this. But maybe I'm wrong. Anyway, I'm not planning to implement this soon.

The interpolation feature of `libmysofa` (and the "neighborhood" search used for that) is currently not used. I'm not planning to add this in this PR, but we might add it later.