### PR TITLE
Travis-CI: run on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,11 +126,5 @@ after_failure:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ls -alhv /usr/bin/ |grep -E "(clang|gcc|g\+\+)"; fi
   - if [[ -f config.log ]]; then cat config.log; fi
 
-branches:
-  only:
-    - master
-    - networking-with-osc
-    - travis-integration
-
 notifications:
   email: false


### PR DESCRIPTION
This way, contributors can enable Travis-CI on their fork and have CI on their branches before creating a PR on the main repo.