### PR TITLE
Browser-GUI: Add two more camera views

### DIFF
--- a/browser-gui/src/index.js
+++ b/browser-gui/src/index.js
@@ -10,6 +10,22 @@ document.body.appendChild(viewport);
 let viewer = new SceneViewer(viewport);
 viewer.animate();
 
+let buttons = document.createElement('div');
+buttons.id = 'buttons';
+let button1 = document.createElement('button');
+button1.textContent = '3D';
+button1.onclick = viewer.switch_to_3d;
+buttons.appendChild( button1 );
+let button2 = document.createElement('button');
+button2.textContent = 'top';
+button2.onclick = viewer.switch_to_top;
+buttons.appendChild( button2 );
+let button3 = document.createElement('button');
+button3.textContent = 'ego';
+button3.onclick = viewer.switch_to_ego;
+buttons.appendChild( button3 );
+document.body.appendChild(buttons);
+
 let socket = new WebSocket('ws://' + HOST + ':' + PORT, 'ssr-json');
 
 socket.onopen = function()

--- a/browser-gui/src/style.css
+++ b/browser-gui/src/style.css
@@ -10,3 +10,14 @@ body {
   right: 0;
   bottom: 0;
 }
+
+#buttons {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 1ex;
+}
+
+button {
+  cursor: pointer;
+}


### PR DESCRIPTION
In addition to the previous "3D" view, this adds a "top" view (using an orthographic camera, kinda like the legacy Qt GUI) and an "ego" view (that moves with the reference [+ reference offset]).

The new cameras don't have "controls" yet, i.e. panning, zooming etc. with the mouse is not possible.