### PR TITLE
Fix auto-rotation for the 3D case

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,6 +119,7 @@ SSRSOURCES = \
 	../gml/include/gml/vec.hpp \
 	../gml/include/gml/quaternion.hpp \
 	../gml/include/gml/util.hpp \
+	../gml/include/gml/mat.hpp \
 	configuration.cpp \
 	configuration.h \
 	controller.h \

--- a/src/controller.h
+++ b/src/controller.h
@@ -2113,8 +2113,10 @@ Controller<Renderer>::_orient_source_toward_reference(id_t id)
     // NB: Reference offset is not taken into account
     //     (because it is a property of the renderer, not the scene)
     auto ref_pos = _scene.get_reference_position();
-    _publish(&api::SceneControlEvents::source_rotation
-        , id, look_at(src->position, ref_pos));
+    if (auto rot = look_rotation(src->position, ref_pos))
+    {
+      _publish(&api::SceneControlEvents::source_rotation, id, *rot);
+    }
   }
   else
   {


### PR DESCRIPTION
This did work fine for 2D, but in 3D situations this caused somewhat erratic rotations.

Now the *up* vector `(0, 0, 1)` is taken into account and everything should be fine.