### PR TITLE
CircleCI: Create tarball

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
 
     environment:
       PIP_INSTALL: python3 -m pip install --user --progress-bar off --upgrade
+      CONFIGURE_FLAGS: --disable-ecasound --disable-gui --disable-ip-interface --disable-websocket-interface --enable-browser-gui
 
     steps:
       - checkout
@@ -69,19 +70,13 @@ jobs:
           destination: SoundScapeRenderer.pdf
 
       - run:
-          name: Configuring SSR (only browser GUI)
+          name: Configuring SSR
           command: |
             ./autogen.sh
-            ./configure \
-              --disable-all \
-              --disable-ecasound \
-              --disable-gui \
-              --disable-ip-interface \
-              --disable-websocket-interface \
-              --enable-browser-gui
+            ./configure $CONFIGURE_FLAGS
 
       - run:
-          name: Building the SSR (only browser GUI files)
+          name: Building the SSR
           command: |
             make
             make DESTDIR=~/install install
@@ -90,6 +85,18 @@ jobs:
           name: Uploading Browser GUI files
           path: ~/install/usr/local/share/ssr/websocket_resources
           destination: browser-gui
+
+      - run:
+          name: Creating tarball
+          command: |
+            make distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_FLAGS"
+            mkdir ~/tarball
+            cp ssr-*.tar.gz ~/tarball
+
+      - store_artifacts:
+          name: Uploading tarball
+          path: ~/tarball
+          destination: .
 
       - run:
           name: Building Doxygen docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ git:
 addons:
   apt:
     #update: true
-    sources:
-      # yarn is only available since Ubuntu 19.04 (disco)
-      - sourceline: 'deb https://dl.yarnpkg.com/debian/ stable main'
-        key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
     packages: &default-packages
       - libasio-dev
       - libwebsocketpp-dev
@@ -29,8 +25,6 @@ addons:
       - pkg-config
       - libtool
       - libmysofa-dev
-      # for browser GUI:
-      - yarn
   homebrew:
     update: true
     packages:
@@ -53,11 +47,6 @@ addons:
 
 matrix:
   include:
-    - name: distcheck with default Linux setup
-      os: linux
-      script:
-        - make
-        - make distcheck
     - name: Linux with GCC 9
       os: linux
       env: CC=gcc-9 CXX=g++-9


### PR DESCRIPTION
Move "make distcheck" from Travis-CI to CircleCI.

This is the generated tarball: https://49-216861629-gh.circle-artifacts.com/0/ssr-0.5.0-100-g99fb884.tar.gz

I found a strange problem when downloading this file with Firefox 70/Linux: The file is double gzipped.
This is probably related to https://bugzilla.mozilla.org/show_bug.cgi?id=610679.

Anyway, it is fine when e.g. downloaded by Chromium.