### PR TITLE
Include browser GUI files in the tarball

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,10 @@ jobs:
           name: Building the SSR
           command: |
             make
-            make DESTDIR=~/install install
 
       - store_artifacts:
           name: Uploading Browser GUI files
-          path: ~/install/usr/local/share/ssr/websocket_resources
+          path: data/websocket_resources
           destination: browser-gui
 
       - run:

--- a/browser-gui/Makefile.am
+++ b/browser-gui/Makefile.am
@@ -5,47 +5,43 @@
 ## comments starting with a single # are copied to Makefile.in (and afterwards
 ## to Makefile), comments with ## are dropped.
 
+if ENABLE_BROWSER_GUI
+
 BROWSER_GUI_FILES = package.json yarn.lock webpack.config.js README.md \
 	src/index.js \
 	src/sceneviewer.js \
 	src/style.css
 
-EXTRA_DIST = $(BROWSER_GUI_FILES)
-
-if ENABLE_BROWSER_GUI
+dist_noinst_DATA = $(BROWSER_GUI_FILES)
 
 export PATH := $(PATH):$(abs_builddir)/node_modules/.bin
 export NODE_PATH := $(abs_builddir)/node_modules
-
-DIST_PATH = $(abs_builddir)/webpack-dist
 
 YARN_OPTIONS = --no-progress --non-interactive \
 	--cwd $(abs_srcdir) \
 	--modules-folder $(NODE_PATH)
 
-all-local: $(DIST_PATH)/index.html
+WEBPACK_PATH = $(abs_builddir)/../data/websocket_resources
+INSTALL_PATH = $(DESTDIR)$(pkgdatadir)/websocket_resources
 
-$(DIST_PATH)/index.html: $(BROWSER_GUI_FILES)
+all-local: $(WEBPACK_PATH)/index.html
+
+$(WEBPACK_PATH)/index.html: $(BROWSER_GUI_FILES)
+	$(RM) -r $(WEBPACK_PATH)/chunks
 	$(YARN) $(YARN_OPTIONS) install
-	$(YARN) $(YARN_OPTIONS) run build --output-path $(DIST_PATH)
+	$(YARN) $(YARN_OPTIONS) run build --output-path $(WEBPACK_PATH)
 
 install-data-hook:
-	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)/websocket_resources/sourcemaps
-	$(INSTALL) -m 644 \
-		$(DIST_PATH)/*.html \
-		$(DIST_PATH)/*.js \
-		$(DESTDIR)$(pkgdatadir)/websocket_resources
-	$(INSTALL) -m 644 \
-		$(DIST_PATH)/sourcemaps/*.js.map \
-		$(DESTDIR)$(pkgdatadir)/websocket_resources/sourcemaps
-
-clean-local:
-	$(RM) -r $(DIST_PATH)
+	$(MKDIR_P) $(INSTALL_PATH)/chunks/sourcemaps
+	$(INSTALL) -m 644 $(WEBPACK_PATH)/index.html $(INSTALL_PATH)
+	$(INSTALL) -m 644 $(WEBPACK_PATH)/chunks/* $(INSTALL_PATH)/chunks
 
 distclean-local:
 	$(RM) -r $(NODE_PATH)
+	$(RM) -r $(WEBPACK_PATH)/index.html
+	$(RM) -r $(WEBPACK_PATH)/chunks
 
 uninstall-local:
-	$(RM) -r $(DESTDIR)$(pkgdatadir)/websocket_resources
+	$(RM) -r $(INSTALL_PATH)
 
 endif

--- a/browser-gui/README.md
+++ b/browser-gui/README.md
@@ -1,17 +1,12 @@
 Browser-based 3D GUI for the SSR
 ================================
 
-To use this, you need to install the [Yarn] package manager.
-Note that the official Debian/Ubuntu package is called `yarnpkg` and the
-executable is also called `yarnpkg` and not `yarn`!
+The auto-generated files for the browser GUI are contained in the tarball within
+the `data/websocket_resources` directory.
 
-[Yarn]: https://yarnpkg.com/en/docs/install
-
-If `yarn` (or `yarnpkg`) is available, the GUI resources are automatically
-created when running `make` and installed with `make install`.
-If you want to make using the GUI explicit, use
-
-    ./configure --enable-browser-gui
+When running `make install`, these files are copied to
+`/usr/local/share/ssr/websocket_resources`
+(unless a different `--prefix` has been specified).
 
 Given that the WebSocket interface is enabled, the SSR will automatically serve
 the resources for the 3D GUI.
@@ -20,19 +15,34 @@ Simply connect with a browser to http://localhost:9422/index.html.
 You can change the server port with the option `--websocket-server=9999`
 (or whatever port you want to use).
 
-Development Build
------------------
+Building the Files
+------------------
 
-If you want to make changes to the source files, you can also build the GUI
-files locally.
+If you want to build the files yourself,
+you need to install the [Yarn] package manager.
+Note that the official Debian/Ubuntu package is called `yarnpkg` and the
+executable is also called `yarnpkg` and not `yarn`!
 
-To install all necessary `npm` packages:
+[Yarn]: https://yarnpkg.com/en/docs/install
+
+If `yarn` (or `yarnpkg`) is available, the browser GUI resources are
+automatically created when running `make`.
+If you want to make generating the GUI files explicit, use
+
+    ./configure --enable-browser-gui
+
+If you make changes to the source files,
+you'll have to run `make` and `make install` again.
+
+During Development
+------------------
+
+You can also build the files outside the SSR build system,
+i.e. without using `make` and `make install`.
+
+Initially, you need to install all necessary `npm` packages:
 
     yarn install
-
-To build the GUI:
-
-    yarn run build
 
 During development, it is very handy if any change to the source files is
 detected and the generated files are updated automatically.

--- a/browser-gui/package.json
+++ b/browser-gui/package.json
@@ -5,7 +5,6 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "clean-webpack-plugin": "^1.0.1",
     "css-loader": "^2.1.0",
     "html-webpack-plugin": "^3.2.0",
     "imports-loader": "^0.8.0",

--- a/browser-gui/webpack.config.js
+++ b/browser-gui/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const webpack = require('webpack');
-const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const DIST_PATH = 'dist';
@@ -9,10 +8,10 @@ const NODE_MODULES = process.env.NODE_PATH || path.join(__dirname, 'node_modules
 module.exports = {
   entry: './src/index.js',
   output: {
-    filename: '[name].[contenthash].js',
-    // When called from the Makefile, this is ignored:
-    path: path.resolve(__dirname, DIST_PATH),
-    sourceMapFilename: 'sourcemaps/[file].map',
+    filename: 'chunks/[name].[contenthash].js',
+    // This is set when called from the Makefile:
+    path: undefined,
+    sourceMapFilename: '[file].map',
   },
   target: 'web',
   module: {
@@ -42,7 +41,6 @@ module.exports = {
     modules: [NODE_MODULES],
   },
   plugins: [
-    new CleanWebpackPlugin([DIST_PATH]),
     new HtmlWebpackPlugin({
       title: 'SoundScape Renderer',
       meta: {
@@ -51,9 +49,6 @@ module.exports = {
     }),
   ],
   devtool: 'source-map',
-  devServer: {
-    contentBase: DIST_PATH
-  },
   mode: 'production',
   optimization: {
     moduleIds: 'hashed',

--- a/browser-gui/yarn.lock
+++ b/browser-gui/yarn.lock
@@ -22,9 +22,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "12.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.7.tgz#57682a9771a3f7b09c2497f28129a0462966524a"
-  integrity sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==
+  version "12.12.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.11.tgz#bec2961975888d964196bf0016a2f984d793d3ce"
+  integrity sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -549,9 +549,9 @@ buffer-xor@^1.0.3:
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^4.3.0:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -685,13 +685,6 @@ clean-css@4.2.x:
   integrity sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==
   dependencies:
     source-map "~0.6.0"
-
-clean-webpack-plugin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-1.0.1.tgz#b16ee2f1386aea403010236e632447c7d3505f5a"
-  integrity sha512-gvwfMsqu3HBgTVvaBa1H3AZKO03CHpr5uP92SPIktP3827EovAitwW+1xoqXyTxCuXnLYpMHG5ytS4AoukHDWA==
-  dependencies:
-    rimraf "^2.6.1"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -993,9 +986,9 @@ decode-uri-component@^0.2.0:
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 deep-equal@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.0.tgz#3103cdf8ab6d32cf4a8df7865458f2b8d33f3745"
-  integrity sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
   dependencies:
     is-arguments "^1.0.4"
     is-date-object "^1.0.1"
@@ -1070,9 +1063,9 @@ depd@~1.1.2:
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
 des.js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
-  integrity sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
+  integrity sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
@@ -1134,9 +1127,9 @@ dom-converter@^0.2:
     utila "~0.4"
 
 dom-serializer@0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
-  integrity sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
   dependencies:
     domelementtype "^2.0.1"
     entities "^2.0.0"
@@ -1281,9 +1274,9 @@ es-abstract@^1.5.1:
     string.prototype.trimright "^2.1.0"
 
 es-to-primitive@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
-  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
@@ -1650,9 +1643,9 @@ glob-parent@^3.1.0:
     path-dirname "^1.0.0"
 
 glob@^7.0.3, glob@^7.1.3, glob@^7.1.4:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.5.tgz#6714c69bee20f3c3e64c4dd905553e532b40cdc0"
-  integrity sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1724,9 +1717,9 @@ has-flag@^3.0.0:
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
-  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2366,9 +2359,9 @@ lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.3:
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 loglevel@^1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.4.tgz#f408f4f006db8354d0577dcf6d33485b3cb90d56"
-  integrity sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.6.tgz#0ee6300cc058db6b3551fa1c4bf73b83bb771312"
+  integrity sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==
 
 lower-case@^1.1.1:
   version "1.1.4"
@@ -2490,22 +2483,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.40.0:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
-  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
-
-"mime-db@>= 1.40.0 < 2":
+mime-db@1.42.0, "mime-db@>= 1.40.0 < 2":
   version "1.42.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
   integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
 
 mime-types@~2.1.17, mime-types@~2.1.24:
-  version "2.1.24"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
-  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  version "2.1.25"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.25.tgz#39772d46621f93e2a80a856c53b86a62156a6437"
+  integrity sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==
   dependencies:
-    mime-db "1.40.0"
+    mime-db "1.42.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -2815,9 +2803,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-inspect@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
-  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
+  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
 object-is@^1.0.1:
   version "1.0.1"
@@ -3151,9 +3139,9 @@ postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
 postcss@^7.0.14, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.21"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
-  integrity sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==
+  version "7.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.23.tgz#9f9759fad661b15964f3cfc3140f66f1e05eadc1"
+  integrity sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -3688,9 +3676,9 @@ source-map-resolve@^0.5.0:
     urix "^0.1.0"
 
 source-map-support@~0.5.12:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
-  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -3935,9 +3923,9 @@ terser-webpack-plugin@^1.4.1:
     worker-farm "^1.7.0"
 
 terser@^4.1.2:
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.9.tgz#e4be37f80553d02645668727777687dad26bbca8"
-  integrity sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.4.0.tgz#22c46b4817cf4c9565434bfe6ad47336af259ac3"
+  integrity sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -4177,9 +4165,9 @@ vary@~1.1.2:
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 vm-browserify@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
-  integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
+  integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 watchpack@^1.6.0:
   version "1.6.0"
@@ -4198,9 +4186,9 @@ wbuf@^1.1.0, wbuf@^1.7.3:
     minimalistic-assert "^1.0.0"
 
 webpack-cli@^3.2.1:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.9.tgz#79c27e71f94b7fe324d594ab64a8e396b9daa91a"
-  integrity sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.10.tgz#17b279267e9b4fb549023fae170da8e6e766da13"
+  integrity sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==
   dependencies:
     chalk "2.4.2"
     cross-spawn "6.0.5"

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,9 @@ dnl see http://sources.redhat.com/automake/automake.html#Options for options
 dnl
 dnl We use the option "foreign" because we do not provide a ChangeLog-file.
 dnl Major changes are documented in the NEWS file.
-AM_INIT_AUTOMAKE([foreign std-options subdir-objects -Wall])
+dnl
+dnl The tar-ustar option allows file names longer than 99 characters
+AM_INIT_AUTOMAKE([foreign std-options subdir-objects -Wall tar-ustar])
 
 dnl Check for pkg-config manually first. If it's not installed the
 dnl PKG_PROG_PKG_CONFIG macro won't be defined.

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -41,6 +41,9 @@ nobase_dist_pkgdata_DATA = \
 	images/ssr_logo.png \
 	websocket_resources/ssr-test-client.html
 
+## the whole directory is distributed, including browser GUI files
+EXTRA_DIST = websocket_resources
+
 ## stuff that will end up either in $prefix/share/ssr/ or in $bundledir/Extras
 nobase_dist_extras_DATA = \
 	reproduction_setups/2.0.asd \


### PR DESCRIPTION
This is the generated tarball: https://63-216861629-gh.circle-artifacts.com/0/ssr-0.5.0-105-ge87d035.tar.gz

It contains these auto-generated files:

* the PDF manual in `doc/`
* the man pages in `man/`
* the browser GUI files in `data/websocket_resources/`


Firefox users please note #183 before downloading the tarball.