### PR TITLE
Send fewer CPU and transport frame events

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -436,6 +436,7 @@ struct SubscribeHelper
   virtual std::unique_ptr<Subscription> renderer_information(
       RendererInformationEvents* subscriber) = 0;
   /// Subscribe to TransportFrameEvents.
+  /// Additionally, this sends the current transport frame to the @a subscriber.
   virtual std::unique_ptr<Subscription> transport_frame(
       TransportFrameEvents* subscriber) = 0;
   /// Subscribe to SourceMetering.

--- a/src/controller.h
+++ b/src/controller.h
@@ -243,9 +243,9 @@ class Controller : public api::Publisher
     /// SceneControlEvents, the rest are arguments to said member function.
     // NB: Args must be convertible to FuncArgs, but they don't necessarily have
     //     to be the same types.
-    template<typename R, typename... FuncArgs, typename... Args>
+    template<typename... FuncArgs, typename... Args>
     void _publish(api::SceneControlEvents* initiator
-        , R (api::SceneControlEvents::*f)(FuncArgs...), Args&&... args)
+        , void (api::SceneControlEvents::*f)(FuncArgs...), Args&&... args)
     {
       // TODO: check if sender is allowed to move source?
 
@@ -263,9 +263,9 @@ class Controller : public api::Publisher
 
     /// Overload for SceneControlEvents to be sent to the "leader".
     /// The first argument is a dummy argument for selecting this overload.
-    template<typename R, typename... FuncArgs, typename... Args>
+    template<typename... FuncArgs, typename... Args>
     void _publish(ToLeaderTag*
-        , R (api::SceneControlEvents::*f)(FuncArgs...), Args&&... args)
+        , void (api::SceneControlEvents::*f)(FuncArgs...), Args&&... args)
     {
       assert(_conf.follow);
       try { _call_leader(f, std::forward<Args>(args)...); }
@@ -275,8 +275,8 @@ class Controller : public api::Publisher
     /// Overload for all events without options to suppress own messages.
     /// Those are never sent to the "leader", therefore it is not allowed to use
     /// this for SceneControlEvents on a "follower".
-    template<typename R, typename C, typename... FuncArgs, typename... Args>
-    void _publish(R (C::*f)(FuncArgs...), Args&&... args)
+    template<typename C, typename... FuncArgs, typename... Args>
+    void _publish(void (C::*f)(FuncArgs...), Args&&... args)
     {
       // NB: Nothing is sent to the "leader"
 

--- a/src/websocket/connection.h
+++ b/src/websocket/connection.h
@@ -184,6 +184,7 @@ private:
     {
       StringBuffer buffer{&_out_allocator};
       Writer writer(buffer, &_out_allocator);
+      writer.SetMaxDecimalPlaces(5);
       commands.Accept(writer);
       _server.send(_hdl, buffer.GetString(), websocketpp::frame::opcode::text);
       SSR_VERBOSE3("output allocator usage: " << _out_allocator.Size());
@@ -985,7 +986,7 @@ Connection::on_message(message_ptr msg)
         SSR_ERROR("Expected JSON object, not " << value);
         return;
       }
-      
+
       if (!control)
       {
         control = _controller.take_control();


### PR DESCRIPTION
JACK's CPU usage estimation typically stays the same for multiple audio blocks. Now it is only sent when it actually changes.

When the JACK transport is stopped, the frame number (which is always the same) is now not sent repeatedly anymore.

Finally, the accuracy of numbers sent via WebSocket is limited to 5 places in order to avoid sending useless data.