### PR TITLE
DOC: switch HTML manual to "insipid" theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Installing Python Packages
           command: |
-            $PIP_INSTALL sphinx sphinx-rtd-theme
+            $PIP_INSTALL -r doc/manual/requirements.txt
 
       - run:
           name: Installing apt Packages

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+python:
+  version: 3
+  install:
+    - requirements: doc/manual/requirements.txt
+  system_packages: true
+
+sphinx:
+  configuration: doc/manual/conf.py
+
+formats:
+  - pdf

--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -6,6 +6,7 @@ from subprocess import check_output
 # -- General configuration -----------------------------------------------------
 
 extensions = [
+    'sphinx_last_updated_by_git',
 ]
 
 master_doc = 'index'
@@ -33,15 +34,14 @@ highlight_language = 'sh'
 
 # -- Options for HTML output ---------------------------------------------------
 
-html_theme = 'sphinx_rtd_theme'
-html_theme_options = {
-    'collapse_navigation': False,
-}
+html_theme = 'insipid'
 html_favicon = 'favicon.svg'
 
 html_domain_indices = False
 html_use_index = False
 html_show_copyright = False
+html_copy_source = False
+html_add_permalinks = '\N{SECTION SIGN}'
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/doc/manual/requirements.txt
+++ b/doc/manual/requirements.txt
@@ -1,0 +1,2 @@
+insipid-sphinx-theme
+sphinx-last-updated-by-git


### PR DESCRIPTION
I didn't like the RTD theme, so I've created my own ...

I've also enable a little Sphinx extension that I've written that shows the last-changed date (based on Git) on each page.

Rendered: https://ssr--227.org.readthedocs.build/en/227/