### PR TITLE
CircleCI: enable linkcheck builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,12 @@ jobs:
           path: doc/doxygen/html
           destination: doxygen
 
+      - run:
+          name: Check for broken links in User Manual
+          command: |
+            cd doc/manual
+            make linkcheck
+
 workflows:
   version: 2
   i-would-like-some-docs:

--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -45,7 +45,7 @@ html_domain_indices = False
 html_use_index = False
 html_show_copyright = False
 html_copy_source = False
-html_add_permalinks = '\N{SECTION SIGN}'
+html_permalinks_icon = '\N{SECTION SIGN}'
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -32,6 +32,10 @@ exclude_patterns = ['_build']
 
 highlight_language = 'sh'
 
+linkcheck_ignore = [
+    r'http://localhost:\d+',
+]
+
 # -- Options for HTML output ---------------------------------------------------
 
 html_theme = 'insipid'

--- a/doc/manual/installation.rst
+++ b/doc/manual/installation.rst
@@ -76,7 +76,7 @@ the resulting packages is to use `makepkg`_ in a `manual build process`_.
 
 .. _AUR: https://aur.archlinux.org
 .. _makepkg: https://wiki.archlinux.org/index.php/Makepkg
-.. _`manual build process`: https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages
+.. _`manual build process`: https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages
 
 
 .. _debian_package:
@@ -149,7 +149,7 @@ Tested with version 0.87 (64 bit) which includes:
 - JackRouter 0.9.3
 - JackPilot 1.7.0
 
-Note that the site http://www.jackosx.com/ is outdated. The latest version of JACK is
+Note that the site ``http://www.jackosx.com/`` is outdated. The latest version of JACK is
 available from http://jackaudio.org/downloads/.
 
 Or, you can install JACK using Homebrew_.

--- a/doc/manual/renderers.rst
+++ b/doc/manual/renderers.rst
@@ -457,7 +457,8 @@ manikin in one of our mid-size meeting rooms called Sputnik with 8
 different source positions. Due to the file size, we have not included
 them in the release. You can obtain the data from [BRIRs]_.
 
-.. [BRIRs] The Sputnik BRIRs can be obtained from here: https://dev.qu.tu-berlin.de/projects/measurements/wiki/Impulse_Response_Measurements.
+.. [BRIRs] The Sputnik BRIRs can be obtained from here:
+    https://github.com/ssr-scenes/tu-berlin/tree/master/sputnik.
     More BRIR repositories are compiled here: http://www.soundfieldsynthesis.org/other-resources/#impulse-responses.
 
 .. _vbap:


### PR DESCRIPTION
status page: https://app.circleci.com/pipelines/github/mgeier/ssr/307/workflows/3e65d625-d4f6-4b1f-b6bd-2c1c33db7d06/jobs/309

The link https://dev.qu.tu-berlin.de/projects/measurements/wiki/Impulse_Response_Measurements (for the Sputnik BRIRs) is currently broken!