### PR TITLE
Leak the GUI

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -749,6 +749,17 @@ bool Controller<Renderer>::run()
 template<typename Renderer>
 Controller<Renderer>::~Controller()
 {
+#ifdef ENABLE_GUI
+  // NB: we are not cleaning up the GUI here!
+
+  // This is to avoid problems with the Static Initialization Order Fiasco, see
+  // https://en.cppreference.com/w/cpp/language/siof
+
+  // If we ever upgrade to Qt6, this might not be necessary anymore.
+
+  _gui.release();  // Forget about the GUI.
+#endif
+
   _renderer.deactivate();
   if (!_conf.follow)
   {


### PR DESCRIPTION
Since #230, the GUI crashed on shutdown with a backtrace that looked something like this:

```
    frame #0: 0x000000010911b6b5 QtCore`QReadWriteLock::tryLockForWrite(int) + 21
    frame #1: 0x00000001084e4caa QtOpenGL`___lldb_unnamed_symbol45$$QtOpenGL + 42
    frame #2: 0x00000001084e54a3 QtOpenGL`QGLContext::~QGLContext() + 35
    frame #3: 0x00000001084e55ce QtOpenGL`QGLContext::~QGLContext() + 14
    frame #4: 0x00000001084e7fb8 QtOpenGL`QGLWidget::~QGLWidget() + 56
    frame #5: 0x0000000104df623b ssr-binaural`ssr::QGUI::~QGUI() [inlined] ssr::QGUI::~QGUI(this=0x00007fc93bd27aa0) at qgui.cpp:213:2 [opt]
    frame #6: 0x0000000104df6224 ssr-binaural`ssr::QGUI::~QGUI() [inlined] ssr::QGUI::~QGUI(this=0x00007fc93bd27aa0) at qgui.cpp:213 [opt]
    frame #7: 0x0000000104df6224 ssr-binaural`ssr::QGUI::~QGUI(this=0x00007fc93bd27aa0) at qgui.cpp:213 [opt]
    frame #8: 0x0000000104dc2ad1 ssr-binaural`ssr::Controller<ssr::BinauralRenderer>::~Controller() [inlined] std::__1::default_delete<ssr::QGUI>::operator(this=<unavailable>, __ptr=<unavailable>)(ssr::QGUI*) const at memory:2368:5 [opt]
```

I'm not sure, but this is probably an instance of the Static Initialization Order Fiasco, see https://en.cppreference.com/w/cpp/language/siof.

Qt uses some `static` variables, e.g. https://doc-snapshots.qt.io/qt5-5.12/qglcontext.html#static-protected-members, and I guess those are deinitialized too early.

The solution in this PR is to simply not deinitialize the GUI at all.

Sounds bad? It probably is.
If you know a better solution, please let us know!

After this PR, when pressing Ctrl+C in the terminal (while the GUI is open but not focused), the JACK client is shut down properly, while previously it wasn't.

I think it is more important to shut down JACK properly than to shut down the GUI.