### PR TITLE
Add example-scenes as Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "flext/flext"]
 	path = flext/flext
 	url = https://github.com/grrrr/flext.git
+[submodule "example-scenes"]
+	path = example-scenes
+	url = https://github.com/SoundScapeRenderer/example-scenes.git


### PR DESCRIPTION
I'm not sure whether that's a good idea ...

I would like to use the BRIR files for the help patch of the upcoming BRS external for Pd.

But for now, I think we should not include the examples in the tarball nor in the macOS App Bundle nor installed in `/usr/local/share/ssr`, or should we?

It would be good to have the examples somewhere in the `$HOME` directory, but for that it's probably still easiest to download them as ZIP from https://github.com/SoundScapeRenderer/example-scenes.