### PR TITLE
Two fixes for the Pd externals

### DIFF
--- a/flext/ssr_brs~.cpp
+++ b/flext/ssr_brs~.cpp
@@ -51,7 +51,7 @@ class SsrFlext<ssr::BrsRenderer> : public SsrFlextBase<ssr::BrsRenderer>
         }
         std::string file_name = _get(argc, argv);
         apf::parameter_map params;
-        params.set("properties-file", _canvasdir / file_name);
+        params.set("properties-file", (_canvasdir / file_name).string());
         auto id = _engine.add_source("", params);
         _engine.get_source(id)->active = true;
         _source_ids.push_back(id);

--- a/flext/ssr_flext.h
+++ b/flext/ssr_flext.h
@@ -130,7 +130,7 @@ class SsrFlextBase : public flext_dsp
       {
         if (params.has_key(key))
         {
-          params.set(key, _canvasdir / params.get<std::string>(key));
+          params.set(key, (_canvasdir / params.get<std::string>(key)).string());
         }
       }
 

--- a/flext/ssr_flext.h
+++ b/flext/ssr_flext.h
@@ -106,12 +106,9 @@ class SsrFlextBase : public flext_dsp
 
   public:
     SsrFlextBase(apf::parameter_map&& params)
-      : _engine(_update_params(std::move(params)))
+      : _canvasdir{_init_canvasdir()}
+      , _engine(_update_params(std::move(params)))
     {
-      char buf[MAXPDSTRING];
-      this->GetCanvasDir(buf, sizeof(buf));
-      _canvasdir = std::filesystem::path{buf};
-
       _engine.load_reproduction_setup();
     }
 
@@ -124,6 +121,14 @@ class SsrFlextBase : public flext_dsp
     }
 
   protected:
+    // NB: This has to be called before _update_params()!
+    std::filesystem::path _init_canvasdir()
+    {
+      char buf[MAXPDSTRING];
+      this->GetCanvasDir(buf, sizeof(buf));
+      return {buf};
+    }
+
     apf::parameter_map _update_params(apf::parameter_map&& params)
     {
       for (const char* key: {"reproduction_setup", "hrir_file", "prefilter_file"})
@@ -549,8 +554,8 @@ class SsrFlextBase : public flext_dsp
     }
 
   protected:
-    Renderer _engine;
     std::filesystem::path _canvasdir;
+    Renderer _engine;
     std::vector<std::string> _source_ids;
 };
 


### PR DESCRIPTION
The first problems was that the paths used in the Pd externals had extra quotes around them.
I didn't understand why, until I saw that the `<<` stream operator adds those quotes, see https://en.cppreference.com/w/cpp/filesystem/path/operator_ltltgtgt!

The solution is to simply convert the paths to strings first.
I'm still not sure whether "native" or "generic" paths should be used here, I guess we'll see once this is used on Windows.

The second problem was that the directory of the Pd patch (a.k.a. "canvas dir") was initialized too late.
I thought I'd have to refactor the whole thing to solve this, but actually, it was quite a simple and localized fix.