### PR TITLE
CI: Improve workflows [WIP]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Build SSR with different compilers
 on: [push, pull_request]
 jobs:
   build:
+    defaults:
+      run:
+        working-directory: 'test path with spaces'
     strategy:
       fail-fast: false
       matrix:
@@ -72,12 +75,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-          path: 'test path with spaces'
-      - name: Change into nasty path
-        run: |
-          pwd
-          cd 'test path with spaces'
-          ls
       - name: Select Xcode
         if: matrix.xcode
         run: |
@@ -143,14 +140,10 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           pwd
-          cd 'test path with spaces'
-          pwd
           ci/build-deps-ubuntu.sh
       - name: Build some macOS dependencies from source
         if: startsWith(matrix.os, 'macos')
         run: |
-          pwd
-          cd 'test path with spaces'
           pwd
           ci/build-deps-macos.sh
       - name: upload VRPN logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+          path: 'test path with spaces'
       - name: Select Xcode
         if: matrix.xcode
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,9 @@ jobs:
         with:
           submodules: true
           path: 'test path with spaces'
+      - name: Change into nasty path
+        run: |
+          cd 'test path with spaces'
       - name: Select Xcode
         if: matrix.xcode
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
     env: ${{ matrix.env }}
     steps:
       - name: Clone Git repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Select Xcode
@@ -143,7 +143,7 @@ jobs:
           ci/build-deps-macos.sh
       - name: upload VRPN logs
         if: failure() && startsWith(matrix.os, 'ubuntu')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }} ${{ matrix.xcode }}${{ env.CXX }} VRPN logs
           path: "vrpn/build/CMakeFiles/*.log"
@@ -170,7 +170,7 @@ jobs:
           ./configure --enable-gui --enable-ip-interface --enable-websocket-interface --enable-fudi-interface --enable-ecasound --enable-sofa --enable-polhemus --enable-razor --enable-vrpn --enable-intersense --disable-browser-gui
       - name: upload config.log
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }} ${{ matrix.xcode }}${{ env.CXX }} configure log
           path: config.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,19 +47,22 @@ jobs:
               CC: clang-9
               CXX: clang++-9
               CXXFLAGS: -fno-builtin
-          - os: macos-latest
-            xcode: Xcode_14
+          - os: macos-12
+            xcode: Xcode_14.0.1
             env: {}
-          - os: macos-latest
+          - os: macos-12
+            xcode: Xcode_13.4.1
+            env: {}
+          - os: macos-11
             xcode: Xcode_13.2.1
             env: {}
-          - os: macos-latest
-            xcode: Xcode_13.1
-            env: {}
-          - os: macos-latest
+          - os: macos-11
             xcode: Xcode_12.5.1
             env: {}
-          - os: macos-latest
+          - os: macos-10.15
+            xcode: Xcode_12.4
+            env: {}
+          - os: macos-10.15
             xcode: Xcode_11.7
             env: {}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,6 @@ name: Build SSR with different compilers
 on: [push, pull_request]
 jobs:
   build:
-    defaults:
-      run:
-        working-directory: 'test path with spaces'
     strategy:
       fail-fast: false
       matrix:
@@ -70,11 +67,15 @@ jobs:
             env: {}
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}
+    defaults:
+      run:
+        working-directory: 'test path with spaces'
     steps:
       - name: Clone Git repo
         uses: actions/checkout@v3
         with:
           submodules: true
+          path: 'test path with spaces'
       - name: Select Xcode
         if: matrix.xcode
         run: |
@@ -151,7 +152,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }} ${{ matrix.xcode }}${{ env.CXX }} VRPN logs
-          path: "vrpn/build/CMakeFiles/*.log"
+          path: 'test path with spaces/vrpn/build/CMakeFiles/*.log'
       - name: Download and unzip InterSense SDK
         run: |
           wget https://www.intersense.com/wp-content/uploads/2018/12/InterSense_SDK_4.2381.zip
@@ -178,7 +179,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }} ${{ matrix.xcode }}${{ env.CXX }} configure log
-          path: config.log
+          path: 'test path with spaces/config.log'
       - run: |
           make
       - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,9 @@ jobs:
               CXX: clang++-9
               CXXFLAGS: -fno-builtin
           - os: macos-latest
+            xcode: Xcode_14
+            env: {}
+          - os: macos-latest
             xcode: Xcode_13.2.1
             env: {}
           - os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,10 @@ jobs:
           path: 'test path with spaces'
       - name: Change into nasty path
         run: |
+          pwd
           cd 'test path with spaces'
+          pwd
+          ls
       - name: Select Xcode
         if: matrix.xcode
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,6 @@ jobs:
         run: |
           pwd
           cd 'test path with spaces'
-          pwd
           ls
       - name: Select Xcode
         if: matrix.xcode
@@ -143,10 +142,16 @@ jobs:
       - name: Build some Linux dependencies from source
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          pwd
+          cd 'test path with spaces'
+          pwd
           ci/build-deps-ubuntu.sh
       - name: Build some macOS dependencies from source
         if: startsWith(matrix.os, 'macos')
         run: |
+          pwd
+          cd 'test path with spaces'
+          pwd
           ci/build-deps-macos.sh
       - name: upload VRPN logs
         if: failure() && startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/pd-externals.yml
+++ b/.github/workflows/pd-externals.yml
@@ -14,7 +14,7 @@ jobs:
           )
           sudo apt-get install --no-install-recommends ${PACKAGES[@]}
       - name: checkout ssr
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           path: ssr
@@ -34,7 +34,7 @@ jobs:
         run: |
           sh pd-lib-builder-iem-ci/pd-lib-builder/localdeps.linux.sh build/ssr_*.pd_linux
       - name: upload Linux externals
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-externals
           path: ssr/flext/build/*
@@ -56,7 +56,7 @@ jobs:
           brew install ${PACKAGES[@]}
           brew install --cask pd
       - name: checkout ssr
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           path: ssr
@@ -65,7 +65,7 @@ jobs:
         run: |
           ./build-small-libsndfile.sh
       - name: checkout libmysofa
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: hoene/libmysofa
           path: libmysofa
@@ -84,7 +84,7 @@ jobs:
         run: |
           sh pd-lib-builder-iem-ci/pd-lib-builder/localdeps.macos.sh build/ssr_*.pd_darwin
       - name: upload macOS externals
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos-externals
           path: ssr/flext/build/*
@@ -117,7 +117,7 @@ jobs:
           rm -f Pd.zip
           export PD="${PROGRAMFILES}/pd/bin/pd.com"
       - name: checkout ssr
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           path: ssr
@@ -137,7 +137,7 @@ jobs:
         run: |
           sh pd-lib-builder-iem-ci/pd-lib-builder/localdeps.win.sh build/ssr_*.dll
       - name: upload Windows externals
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-externals
           path: ssr/flext/build/*
@@ -147,22 +147,22 @@ jobs:
     needs: [linux, macos, windows]
     steps:
       - name: Clone Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # check out all tags to get proper version in Deken package
           fetch-depth: 0
       - name: Retrieve Linux externals
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-externals
           path: ssr
       - name: Retrieve macOS external
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: macos-externals
           path: ssr
       - name: Retrieve Windows external
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-externals
           path: ssr
@@ -176,7 +176,7 @@ jobs:
         run: |
           deken package -v $(git describe --tags --always) --objects flext/objects.txt ssr
       - name: Upload deken package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Deken package
           path: "*.dek*"

--- a/.github/workflows/pd-externals.yml
+++ b/.github/workflows/pd-externals.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
           path: 'test path with spaces/ssr'
       - name: Build dependencies
-        working-directory: ssr/ci
+        working-directory: 'test path with spaces/ssr/ci'
         run: |
           sudo chown -R $(whoami):admin /usr/local
           ./build-small-libsndfile.sh
@@ -61,7 +61,7 @@ jobs:
           submodules: true
           path: 'test path with spaces/ssr'
       - name: Build dependencies
-        working-directory: ssr/ci
+        working-directory: 'test path with spaces/ssr/ci'
         run: |
           ./build-small-libsndfile.sh
       - name: checkout libmysofa

--- a/.github/workflows/pd-externals.yml
+++ b/.github/workflows/pd-externals.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-          path: ssr
+          path: 'test path with spaces/ssr'
       - name: Build dependencies
         working-directory: ssr/ci
         run: |
@@ -26,18 +26,18 @@ jobs:
           ./build-small-libxml2.sh
           sudo ldconfig
       - name: build externals
-        working-directory: ssr/flext
+        working-directory: 'test path with spaces/ssr/flext'
         run: |
           make install DESTDIR=build PDLIBDIR=
       - name: Fix pd_linux dependencies
-        working-directory: ssr/flext
+        working-directory: 'test path with spaces/ssr/flext'
         run: |
           sh pd-lib-builder-iem-ci/pd-lib-builder/localdeps.linux.sh build/ssr_*.pd_linux
       - name: upload Linux externals
         uses: actions/upload-artifact@v3
         with:
           name: linux-externals
-          path: ssr/flext/build/*
+          path: 'test path with spaces/ssr/flext/build/*'
 
   macos:
     runs-on: macos-latest
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-          path: ssr
+          path: 'test path with spaces/ssr'
       - name: Build dependencies
         working-directory: ssr/ci
         run: |
@@ -68,26 +68,26 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: hoene/libmysofa
-          path: libmysofa
+          path: 'test path with spaces/libmysofa'
       - name: build libmysofa
-        working-directory: libmysofa/build
+        working-directory: 'test path with spaces/libmysofa/build'
         run: |
           cmake ..
           make
           make install
       - name: build externals
-        working-directory: ssr/flext
+        working-directory: 'test path with spaces/ssr/flext'
         run: |
           make install DESTDIR=build PDLIBDIR=
       - name: Fix pd_darwin dependencies
-        working-directory: ssr/flext
+        working-directory: 'test path with spaces/ssr/flext'
         run: |
           sh pd-lib-builder-iem-ci/pd-lib-builder/localdeps.macos.sh build/ssr_*.pd_darwin
       - name: upload macOS externals
         uses: actions/upload-artifact@v3
         with:
           name: macos-externals
-          path: ssr/flext/build/*
+          path: 'test path with spaces/ssr/flext/build/*'
 
   windows:
     runs-on: windows-latest
@@ -120,27 +120,27 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-          path: ssr
+          path: 'test path with spaces/ssr'
       - name: Build dependencies
-        working-directory: ssr/ci
+        working-directory: 'test path with spaces/ssr/ci'
         run: |
           # https://github.com/msys2/MINGW-packages/issues/5803
           export LIBS=-lssp
           ./build-small-libsndfile.sh
           ./build-small-libxml2.sh
       - name: build externals
-        working-directory: ssr/flext
+        working-directory: 'test path with spaces/ssr/flext'
         run: |
           make install DESTDIR=build PDLIBDIR=
       - name: Fix dll dependencies
-        working-directory: ssr/flext
+        working-directory: 'test path with spaces/ssr/flext'
         run: |
           sh pd-lib-builder-iem-ci/pd-lib-builder/localdeps.win.sh build/ssr_*.dll
       - name: upload Windows externals
         uses: actions/upload-artifact@v3
         with:
           name: windows-externals
-          path: ssr/flext/build/*
+          path: 'test path with spaces/ssr/flext/build/*'
 
   deken-package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I ran into a compilation issue locally, and figured that it was not covered in the CI workflow. So far, I have done a couple of things that are outside of the scope of my initial issue. These things should be discussed if you even want them, and potentially be split into separate PRs.
- [x] Add to not fail fast (maybe should be removed again?)
- [x] Split `macos-latest` configurations into discrete versions `macos-10.15`, `macos-11`, `macos-12` and compile either of them with the two latest supported xcode versions (seems useful, but maybe too explicit?)
- [x] ~~Fix workflow issue with build "(macos-12, Xcode_13.4.1)"~~
- [x] Update from  `actions/checkout@v2` to `actions/checkout@v3`
- [x] Update from  `actions/upload-artifact@v2` to `actions/upload-artifact@v3`
- [x] Test a spaced path in all workflow steps of `main.yml` (this is what currently still fails)
- [x] Test a spaced path in all workflow steps of `pd-externals.yml` (this currently fails only for `macos-latest`)
- [ ] Fix workflow issues when using a spaced path
- [ ] Find a nicer way (or remove changes) to run workflows with a spaced path