### PR TITLE
Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,11 @@ jobs:
             ./autogen.sh
             ./configure $CONFIGURE_FLAGS
 
+      - store_artifacts:
+          name: Uploading config.log
+          path: config.log
+          destination: config.log
+
       - run:
           name: Building the SSR
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             apt-get update
             apt-get install -y \
               automake \
+              binutils \
               doxygen \
               help2man \
               libfftw3-dev \


### PR DESCRIPTION
There was a strange error when running `./configure`, which was fixed by installing (upgrading?) the `binutils` package.