### PR TITLE
Update macOS instructions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,6 +97,7 @@ jobs:
             pkg-config
             qt@5
             vrpn
+            websocketpp
           )
           brew install ${PACKAGES[@]}
           brew link qt@5 --force

--- a/ci/build-deps-macos.sh
+++ b/ci/build-deps-macos.sh
@@ -2,16 +2,6 @@
 
 set -euo pipefail
 
-git clone https://github.com/zaphoyd/websocketpp.git
-cd websocketpp
-mkdir build
-cd build
-cmake ..
-make
-sudo make install
-cd ..
-cd ..
-
 git clone https://github.com/hoene/libmysofa.git
 cd libmysofa
 cd build

--- a/doc/manual/building-from-source.rst
+++ b/doc/manual/building-from-source.rst
@@ -113,7 +113,24 @@ For playing/recording audio files:
 
 For the GUI:
 
-- ``libqt5-opengl-dev`` or ``qt`` (``brew link qt --force`` might be needed)
+- ``libqt5-opengl-dev`` or ``qt@5``
+
+  When installing ``qt@5`` with ``brew``,
+  this command should be run before compiling the SSR::
+
+      brew link qt@5 --force
+
+  However, if you already have a newer version of Qt installed
+  (for example if you installed the very useful package ``qjackctl``),
+  you have to run this first::
+
+      brew unlink qt
+
+  Once the SSR is successfully compiled,
+  you can switch back to the newer Qt version
+  (otherwise ``qjackctl`` will not work anymore)::
+
+      brew link qt
 
 For all network interfaces:
 
@@ -121,7 +138,7 @@ For all network interfaces:
 
 For the WebSocket interface:
 
-- ``libwebsocketpp-dev`` (has to be compiled from source on macOS)
+- ``libwebsocketpp-dev`` or ``websocketpp``
 
 For the FUDI network interface:
 
@@ -146,7 +163,7 @@ For a concrete list of Ubuntu and Homebrew packages,
 see the CI configuration file
 :download:`.github/workflows/main.yml <../../.github/workflows/main.yml>`.
 
-For instructions to compile and install ``websocketpp`` and ``libmysofa``
+For instructions to compile and install ``libmysofa``
 on macOS, have a look at the file
 :download:`ci/build-deps-macos.sh <../../ci/build-deps-macos.sh>`
 (``cmake`` must be installed).

--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -12,7 +12,7 @@ extensions = [
 master_doc = 'index'
 
 project = u'SoundScape Renderer'
-copyright = u'2018, SSR Team'
+copyright = u'2022, SSR Team'
 
 try:
     release = check_output(['git', 'describe', '--tags', '--always'])
@@ -45,7 +45,7 @@ html_domain_indices = False
 html_use_index = False
 html_show_copyright = False
 html_copy_source = False
-html_permalinks_icon = '\N{SECTION SIGN}'
+html_permalinks_icon = '#'
 
 # -- Options for LaTeX output --------------------------------------------------
 


### PR DESCRIPTION
`websocketpp` is now available with `brew`, so we don't need to build it from source anymore.

And I clarified the installation and (un)linking of `qt@5`.

Rendered HTML page: https://output.circle-artifacts.com/output/job/3d231f34-bdac-48ac-b404-a44e00e750b2/artifacts/0/manual/building-from-source.html#dependencies