### PR TITLE
configure: check for pre-built manpages and browser-gui resources

### DIFF
--- a/browser-gui/Makefile.am
+++ b/browser-gui/Makefile.am
@@ -21,7 +21,7 @@ YARN_OPTIONS = --no-progress --non-interactive \
 	--cwd "$(abs_srcdir)" \
 	--modules-folder "$(NODE_PATH)"
 
-WEBPACK_PATH = "$(abs_builddir)/../data/websocket_resources"
+WEBPACK_PATH = ../data/websocket_resources
 INSTALL_PATH = "$(DESTDIR)$(pkgdatadir)/websocket_resources"
 
 all-local: $(WEBPACK_PATH)/index.html
@@ -32,7 +32,7 @@ $(WEBPACK_PATH)/index.html: $(BROWSER_GUI_FILES)
 	$(YARN) $(YARN_OPTIONS) run build --output-path $(WEBPACK_PATH)
 
 install-data-hook:
-	$(MKDIR_P) $(INSTALL_PATH)/chunks/sourcemaps
+	$(MKDIR_P) $(INSTALL_PATH)/chunks
 	$(INSTALL) -m 644 $(WEBPACK_PATH)/index.html $(INSTALL_PATH)
 	$(INSTALL) -m 644 $(WEBPACK_PATH)/chunks/* $(INSTALL_PATH)/chunks
 

--- a/configure.ac
+++ b/configure.ac
@@ -123,12 +123,6 @@ dnl AC_DEFINE writes values in config.h
 dnl AC_DEFINE_UNQUOTED performs additional shell expansions, e.g. substitution
 dnl of variable with value.
 
-AC_CHECK_PROG([have_help2man], [help2man], [yes], [no])
-AM_CONDITIONAL([HAVE_HELP2MAN], [test x$have_help2man = xyes])
-AS_IF([test x$have_help2man != xyes],
- AC_MSG_WARN([Disabling manpage generation due to missing help2man])
-)
-
 ENABLE_AUTO([all],
             [all renderers (use --enable-xyz to re-enable certain renderers)],
 [
@@ -179,6 +173,27 @@ ENABLE_AUTO([dca],[Distance-coded Ambisonics renderer],
 
 dnl Note: For what happens with SSR_executables see src/Makefile.am
 AC_SUBST(SSR_executables)
+
+AC_MSG_CHECKING([for pre-built manpages])
+have_manpages=yes
+for exe in $SSR_executables
+do
+  AS_IF([test -f $srcdir/man/$exe.1], [], [have_manpages=no])
+done
+AS_IF([test x$have_manpages != xyes], [
+  AC_MSG_RESULT([no])
+  AC_CHECK_PROG([have_help2man], [help2man], [yes], [no])
+  have_manpages=$have_help2man
+], [
+  AS_IF([test $srcdir != .], [
+    AC_CONFIG_COMMANDS([manpages], [cp $srcdir/man/*.1 man/])
+  ])
+  AC_MSG_RESULT([yes])
+])
+AM_CONDITIONAL([HAVE_MANPAGES], [test x$have_manpages = xyes])
+AS_IF([test x$have_manpages != xyes],
+ AC_MSG_WARN([Disabling manpage generation due to missing help2man]),
+)
 
 dnl Checking for sndfile
 PKG_CHECK_MODULES([SNDFILE], [sndfile >= 1.0],
@@ -727,7 +742,16 @@ ENABLE_AUTO([browser-gui], [creation of HTML/JavaScript files for browser GUI],
 [
   AC_ARG_VAR([YARN], [Yarn package manager command])
   AC_CHECK_PROGS([YARN], [yarnpkg yarn])
-  AS_IF([test -n "$YARN"], , [have_browser_gui=no])
+  AS_IF([test -f $srcdir/data/websocket_resources/index.html -a $srcdir != .], [
+    AC_CONFIG_COMMANDS(
+      [data/websocket_resources/index.html],
+      [cp $srcdir/data/websocket_resources/index.html data/websocket_resources])
+    AC_CONFIG_COMMANDS(
+      [data/websocket_resources/chunks],
+      [cp -rf $srcdir/data/websocket_resources/chunks data/websocket_resources])
+  ], [
+    AS_IF([test -n "$YARN"], [], [have_browser_gui=no])
+  ])
 ])
 
 AC_SUBST(DMG_NAME)
@@ -818,7 +842,7 @@ AS_IF([test x$have_ecasound = xyes -a x$have_ecasound_program != xyes],
   echo "|>  WARNING: Ecasound (the program, not the library) was not found!"
   echo "|>  It is needed for playing (and recording) sound files with the SSR."
 ])
-AS_IF([test x$have_help2man != xyes],
+AS_IF([test x$have_manpages != xyes],
 [
   echo "|"
   echo "|>  WARNING: help2man was not found!"

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -5,7 +5,7 @@
 ## comments starting with a single # are copied to Makefile.in (and afterwards
 ## to Makefile), comments with ## are dropped.
 
-if HAVE_HELP2MAN
+if HAVE_MANPAGES
 dist_man_MANS = $(SSR_executables:=.1)
 endif
 
@@ -29,3 +29,6 @@ $(dist_man_MANS): $(top_srcdir)/src/configuration.cpp $(top_srcdir)/configure.ac
                 --name=$(RENDERER_TEXT) \
                 --output=$@ \
                 --locale=$(HELP2MAN_LOCALE) $(top_builddir)/src/$(@:.1=$(EXEEXT))
+
+distclean-local:
+	$(RM) *.1


### PR DESCRIPTION
In the past, I have made sure that the tarball contains the manpages and the browser-gui files, but today I found out that this is quite useless, because those files are not used when building the SSR from the tarball!

With the changes in this PR, it hopefully works now.