### PR TITLE
Manual: use unabbreviated first names in Spors2011 reference

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,8 +2,12 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
 python:
-  version: 3
   install:
     - requirements: doc/manual/requirements.txt
   system_packages: true

--- a/doc/manual/renderers.rst
+++ b/doc/manual/renderers.rst
@@ -741,7 +741,7 @@ Note that the DCA renderer is experimental at this stage. It currently supports 
 
 Please bear with us. We are going to take care of this soon.
 
-.. [Spors2011] S. Spors, V. Kuscher, and J. Ahrens. Efficient Realization of Model-Based Rendering for 2.5-dimensional Near-Field Compensated Higher Order Ambisonics. In IEEE WASPAA, New Paltz, NY, USA, 2011.
+.. [Spors2011] Sascha Spors, Vincent Kuscher, and Jens Ahrens. Efficient Realization of Model-Based Rendering for 2.5-dimensional Near-Field Compensated Higher Order Ambisonics. In IEEE WASPAA, New Paltz, NY, USA, 2011.
 
 .. _genren:
 


### PR DESCRIPTION
Using a letter followed by a dot seems to lead to strange formatting (the line is turned into an ordered list): https://ssr.readthedocs.io/en/latest/renderers.html#spors2011

Also, all other references have the full first names.