### PR TITLE
CircleCI: Don't build Doxygen docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  build_docs:
+  tarball:
     docker:
       # https://github.com/dante-ev/docker-texlive
       - image: danteev/texlive
@@ -37,7 +37,6 @@ jobs:
             apt-get install -y \
               automake \
               binutils \
-              doxygen \
               help2man \
               libfftw3-dev \
               libjack-jackd2-dev \
@@ -103,16 +102,6 @@ jobs:
           path: ~/tarball
           destination: .
 
-      - run:
-          name: Building Doxygen docs
-          command: |
-            make doc
-
-      - store_artifacts:
-          name: Uploading Doxygen HTML files
-          path: doc/doxygen/html
-          destination: doxygen
-
       - store_artifacts:
           name: Uploading HTML Manual
           path: doc/manual/_build/html
@@ -136,6 +125,6 @@ jobs:
 
 workflows:
   version: 2
-  i-would-like-some-docs:
+  build:
     jobs:
-      - build_docs
+      - tarball


### PR DESCRIPTION
TBH, I don't think that anybody is reading those docs anyway, right?

This would reduce the CI time significantly. Building the docs only takes about 20 seconds, but uploading hundreds of HTML files takes 2.5 minutes.

If needed, they can be built locally with `make doc`.

The HTML version of the user manual is still built, but this is no problem because it's much faster (a few seconds).