### PR TITLE
Pd externals: build with NDEBUG

### DIFF
--- a/flext/Makefile
+++ b/flext/Makefile
@@ -11,6 +11,7 @@ cflags += \
        `$(PKG_CONFIG) --cflags libxml-2.0` \
        -std=c++17 \
        -DENABLE_SOFA \
+       -DNDEBUG \
 
 define forDarwin
   cflags += -mmacosx-version-min=10.15


### PR DESCRIPTION
I have just realized that the `assert()` calls are enabled for the Pd externals.

I first thought that optimizations are disabled, but that's not the case.

We only need to define `NDEBUG` to disable `assert()`s.