### PR TITLE
Extend pathtools cross-platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
               CC: gcc-12
               CXX: g++-12
           - os: ubuntu-20.04
-            compiler-pkg: g++-8
+            compiler-pkg: g++-9
             env:
-              CC: gcc-8
-              CXX: g++-8
+              CC: gcc-9
+              CXX: g++-9
           - os: ubuntu-22.04
             compiler-pkg: clang-14
             env:

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -192,14 +192,17 @@ ssr::conf_struct ssr::configuration(int& argc, char* argv[])
   load_config_file("/Library/SoundScapeRenderer/ssr.conf",conf);
   // load system-wide config file (Linux et al.)
   load_config_file("/etc/ssr.conf",conf);
-  // load user config file (Mac)
-  fs::path home_dir = pathtools::get_home_dir();
-  fs::path conf_file;
-  conf_file = home_dir / "Library/SoundScapeRenderer/ssr.conf";
-  load_config_file(conf_file.make_preferred().string().c_str(),conf);
-  // load user config file (Linux et al.)
-  conf_file = home_dir / ".ssr/ssr.conf";
-  load_config_file(conf_file.make_preferred().string().c_str(),conf);
+
+  if (auto home_dir = pathtools::get_home_dir(); home_dir != fs::path())
+  {
+    fs::path conf_file;
+    // load user config file (Mac)
+    conf_file = home_dir / "Library" / "SoundScapeRenderer" / "ssr.conf";
+    load_config_file(conf_file.make_preferred().string().c_str(),conf);
+    // load user config file (Linux et al.)
+    conf_file = home_dir / ".ssr" / "ssr.conf";
+    load_config_file(conf_file.make_preferred().string().c_str(),conf);
+  }
 
   const std::string usage_string =
 "Usage: " + std::string(conf.exec_name) + " [OPTIONS] <scene-file>\n";

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -193,13 +193,13 @@ ssr::conf_struct ssr::configuration(int& argc, char* argv[])
   // load system-wide config file (Linux et al.)
   load_config_file("/etc/ssr.conf",conf);
   // load user config file (Mac)
-  std::string home_dir = pathtools::get_home_dir().string();
-  std::string conf_file;
-  conf_file = pathtools::normalize_path(home_dir + "/Library/SoundScapeRenderer/ssr.conf");
-  load_config_file(conf_file.c_str(),conf);
+  fs::path home_dir = pathtools::get_home_dir();
+  fs::path conf_file;
+  conf_file = home_dir / "Library/SoundScapeRenderer/ssr.conf";
+  load_config_file(conf_file.make_preferred().string().c_str(),conf);
   // load user config file (Linux et al.)
-  conf_file = pathtools::normalize_path(home_dir + "/.ssr/ssr.conf");
-  load_config_file(conf_file.c_str(),conf);
+  conf_file = home_dir / ".ssr/ssr.conf";
+  load_config_file(conf_file.make_preferred().string().c_str(),conf);
 
   const std::string usage_string =
 "Usage: " + std::string(conf.exec_name) + " [OPTIONS] <scene-file>\n";

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -193,12 +193,14 @@ ssr::conf_struct ssr::configuration(int& argc, char* argv[])
   // load system-wide config file (Linux et al.)
   load_config_file("/etc/ssr.conf",conf);
   // load user config file (Mac)
-  std::string filename = getenv("HOME");
+  std::string filename = pathtools::get_home_dir().string();
   filename += "/Library/SoundScapeRenderer/ssr.conf";
+  filename = pathtools::normalize_path(filename);
   load_config_file(filename.c_str(),conf);
   // load user config file (Linux et al.)
-  filename = getenv("HOME");
+  filename = pathtools::get_home_dir().string();
   filename += "/.ssr/ssr.conf";
+  filename = pathtools::normalize_path(filename);
   load_config_file(filename.c_str(),conf);
 
   const std::string usage_string =

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -193,15 +193,13 @@ ssr::conf_struct ssr::configuration(int& argc, char* argv[])
   // load system-wide config file (Linux et al.)
   load_config_file("/etc/ssr.conf",conf);
   // load user config file (Mac)
-  std::string filename = pathtools::get_home_dir().string();
-  filename += "/Library/SoundScapeRenderer/ssr.conf";
-  filename = pathtools::normalize_path(filename);
-  load_config_file(filename.c_str(),conf);
+  fs::path home_dir = pathtools::get_home_dir();
+  fs::path conf_file;
+  conf_file = pathtools::normalize_path(home_dir / "Library/SoundScapeRenderer/ssr.conf");
+  load_config_file(conf_file.c_str(),conf);
   // load user config file (Linux et al.)
-  filename = pathtools::get_home_dir().string();
-  filename += "/.ssr/ssr.conf";
-  filename = pathtools::normalize_path(filename);
-  load_config_file(filename.c_str(),conf);
+  conf_file = pathtools::normalize_path(home_dir / ".ssr/ssr.conf");
+  load_config_file(conf_file.c_str(),conf);
 
   const std::string usage_string =
 "Usage: " + std::string(conf.exec_name) + " [OPTIONS] <scene-file>\n";

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -193,12 +193,12 @@ ssr::conf_struct ssr::configuration(int& argc, char* argv[])
   // load system-wide config file (Linux et al.)
   load_config_file("/etc/ssr.conf",conf);
   // load user config file (Mac)
-  fs::path home_dir = pathtools::get_home_dir();
-  fs::path conf_file;
-  conf_file = pathtools::normalize_path(home_dir / "Library/SoundScapeRenderer/ssr.conf");
+  std::string home_dir = pathtools::get_home_dir().string();
+  std::string conf_file;
+  conf_file = pathtools::normalize_path(home_dir + "/Library/SoundScapeRenderer/ssr.conf");
   load_config_file(conf_file.c_str(),conf);
   // load user config file (Linux et al.)
-  conf_file = pathtools::normalize_path(home_dir / ".ssr/ssr.conf");
+  conf_file = pathtools::normalize_path(home_dir + "/.ssr/ssr.conf");
   load_config_file(conf_file.c_str(),conf);
 
   const std::string usage_string =

--- a/src/controller.h
+++ b/src/controller.h
@@ -1526,7 +1526,7 @@ Controller<Renderer>::_load_scene(const std::string& scene_file_name)
     return true;
   }
 
-  std::string file_extension = fs::path(scene_file_name).extension();
+  std::string file_extension = fs::path(scene_file_name).extension().string();
 
   if (file_extension == "")
   {
@@ -2307,7 +2307,7 @@ Controller<Renderer>::_add_sources(Node& node
       {
         _add_audio_file_name(source_node
             , pathtools::make_path_relative_to_file(source.audio_file_name
-              , scene_file_name), source.audio_file_channel);
+              , scene_file_name).string(), source.audio_file_channel);
       }
     }
 
@@ -2341,7 +2341,7 @@ Controller<Renderer>::_add_sources(Node& node
     {
       source_node.new_attribute("properties-file"
           , pathtools::make_path_relative_to_file(source.properties_file
-            , scene_file_name));
+            , scene_file_name).string());
     }
   });
 }

--- a/src/gui/qgui.cpp
+++ b/src/gui/qgui.cpp
@@ -203,7 +203,9 @@ ssr::QGUI::QGUI(api::Publisher& controller, const LegacyScene& scene, int &argc,
     , path_to_gui_images, path_to_scene_menu)
 {
   // this is a quick hack to allow dynamic specification of path
-  qt_style_sheet.replace(QString("images"), QString( path_to_gui_images.c_str() ));
+  QString url_to_gui_images = path_to_gui_images.c_str();
+  url_to_gui_images.replace(QString("\\"), "/");  // url needs all forward
+  qt_style_sheet.replace(QString("images"), url_to_gui_images);
 
   // set stylesheet
   _qt_app.setStyleSheet(qt_style_sheet);

--- a/src/pathtools.h
+++ b/src/pathtools.h
@@ -77,9 +77,38 @@ inline std::string make_path_relative_to_current_dir(const std::string& path
   auto p = fs::path{path};
   if (p.is_absolute() || p == "")
   {
-    return p;
+    return p.make_preferred().string();
   }
-  return fs::relative(fs::absolute(filename).parent_path() / p).string();
+  return fs::relative(fs::absolute(filename).parent_path() / p).make_preferred().string();
+}
+
+/** Cleanup @p path, e.g. by adjusting and removing duplicate separators. 
+ * @param path A path given
+ * @return @p path in a canonical and native format.
+ **/
+inline std::string normalize_path(const std::string& path) {
+    fs::path p_canonical = fs::weakly_canonical(path);
+    std::string p_norm = p_canonical.make_preferred().string();
+    return p_norm;
+}
+
+/** Tries to find a home path, otherwise returns the root path.
+ * @return home path
+ **/
+inline fs::path get_home_dir()
+{
+  fs::path p_home = fs::current_path().root_path();
+  char const* home = getenv("HOME");
+  if (home)
+  {
+    p_home = fs::path(home);
+  }
+  home = getenv("USERPROFILE");
+  if (home)
+  {
+    p_home = fs::path(home);
+  }
+  return p_home;
 }
 
 /** Insert escape characters (\) before whitespace characters.

--- a/src/pathtools.h
+++ b/src/pathtools.h
@@ -92,7 +92,7 @@ inline std::string normalize_path(const std::string& path) {
     return p_norm;
 }
 
-/** Tries to find a home path, otherwise returns the current path.
+/** Tries to find a home path, otherwise returns path().
  * @return home path
  **/
 inline fs::path get_home_dir()
@@ -107,7 +107,7 @@ inline fs::path get_home_dir()
   {
     return fs::path{home};
   }
-  return fs::current_path();
+  return fs::path();
 }
 
 /** Insert escape characters (\) before whitespace characters.

--- a/src/pathtools.h
+++ b/src/pathtools.h
@@ -92,23 +92,22 @@ inline std::string normalize_path(const std::string& path) {
     return p_norm;
 }
 
-/** Tries to find a home path, otherwise returns the root path.
+/** Tries to find a home path, otherwise returns the current path.
  * @return home path
  **/
 inline fs::path get_home_dir()
 {
-  fs::path p_home = fs::current_path().root_path();
-  char const* home = getenv("HOME");
+  const char* home = getenv("HOME");
   if (home)
   {
-    p_home = fs::path(home);
+    return fs::path{home};
   }
   home = getenv("USERPROFILE");
   if (home)
   {
-    p_home = fs::path(home);
+    return fs::path{home};
   }
-  return p_home;
+  return fs::current_path();
 }
 
 /** Insert escape characters (\) before whitespace characters.

--- a/src/pathtools.h
+++ b/src/pathtools.h
@@ -82,16 +82,6 @@ inline std::string make_path_relative_to_current_dir(const std::string& path
   return fs::relative(fs::absolute(filename).parent_path() / p).make_preferred().string();
 }
 
-/** Cleanup @p path, e.g. by adjusting and removing duplicate separators. 
- * @param path A path given
- * @return @p path in a canonical and native format.
- **/
-inline std::string normalize_path(const std::string& path) {
-    fs::path p_canonical = fs::weakly_canonical(path);
-    std::string p_norm = p_canonical.make_preferred().string();
-    return p_norm;
-}
-
 /** Tries to find a home path, otherwise returns path().
  * @return home path
  **/


### PR DESCRIPTION
Introduce `get_home_dir()` and `normalize_path()`.