### PR TITLE
CI: drop support for gcc 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
               CC: gcc-12
               CXX: g++-12
           - os: ubuntu-20.04
-            compiler-pkg: g++-8
+            compiler-pkg: g++-9
             env:
-              CC: gcc-8
-              CXX: g++-8
+              CC: gcc-9
+              CXX: g++-9
           - os: ubuntu-22.04
             compiler-pkg: clang-14
             env:


### PR DESCRIPTION
GCC 8 made problems in #337, so let's get rid of it!

That's the underlying problem in case somebody is interested: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90050