### PR TITLE
Use properties_file instead of properties-file when saving ASD

### DIFF
--- a/mex/ssr_mex.h
+++ b/mex/ssr_mex.h
@@ -214,7 +214,7 @@ class SsrMex
 
         if (!filename_list.empty())
         {
-          source_params.set("properties_file", filename_list[i]);
+          source_params.set("properties-file", filename_list[i]);
         }
         auto id = _engine->add_source("", source_params);
         _source_ids.push_back(id);

--- a/src/controller.h
+++ b/src/controller.h
@@ -2339,7 +2339,7 @@ Controller<Renderer>::_add_sources(Node& node
 
     if (source.properties_file != "")
     {
-      source_node.new_attribute("properties-file"
+      source_node.new_attribute("properties_file"
           , pathtools::make_path_relative_to_file(source.properties_file
             , scene_file_name));
     }

--- a/src/legacy_network/commandparser.cpp
+++ b/src/legacy_network/commandparser.cpp
@@ -200,10 +200,10 @@ CommandParser::parse_cmd(const std::string& cmd)
         SSR_VERBOSE2("set source name: id = " << id << ", name = " << name);
       }
 
-      std::string properties_file = i.get_attribute("properties-file");
+      std::string properties_file = i.get_attribute("properties_file");
       if (!properties_file.empty() && !new_source)
       {
-        SSR_ERROR("Cannot set properties-file! This works only for new sources.");
+        SSR_ERROR("Cannot set properties_file! This works only for new sources.");
       }
 
       std::string model = i.get_attribute("model");


### PR DESCRIPTION
A few years ago, I changed a few underscores to hyphens: c06e61706a3c60e9966069992ec23999445e2c9e

It turns out that I was a bit over-eager and also changed an XML attribute which I shouldn't have changed.

This fixes a part of #345.