### PR TITLE
CI: try cross-compiling macOS Pd externals

### DIFF
--- a/.github/workflows/pd-externals.yml
+++ b/.github/workflows/pd-externals.yml
@@ -67,7 +67,7 @@ jobs:
       - name: build externals
         working-directory: ssr/flext
         run: |
-          make install DESTDIR=build PDLIBDIR=
+          make install DESTDIR=build PDLIBDIR= arch="arm64 x86_64"
       - name: Fix pd_darwin dependencies
         working-directory: ssr/flext
         run: |


### PR DESCRIPTION
This is for now just an idea, I don't know if it will work.

Cross-compiling the external itself shouldn't be too much of a problem, but getting the dependencies compiled might be harder.

The two architectures might need different extensions:

    make extension=d_arm64
    make extension=d_amd64

The libraries for arm64 can probably be installed like described here: https://stackoverflow.com/questions/70821136/can-i-install-arm64-libraries-on-x86-64-with-homebrew/70822921