### PR TITLE
CI: use fetch-tags for Deken

### DIFF
--- a/.github/workflows/pd-externals.yml
+++ b/.github/workflows/pd-externals.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           # check out all tags to get proper version in Deken package
-          fetch-depth: 0
+          fetch-tags: true
       - name: Retrieve Linux externals
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This doesn't work yet, it needs a new release (> 3.5.3) of the "checkout" action.

See https://github.com/actions/checkout/pull/579