### PR TITLE
Improve Qt5 linking on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,11 @@ jobs:
             websocketpp
           )
           brew install ${PACKAGES[@]}
-          brew link qt@5 --force
+          # Link keg-only Qt5 according to homebrew info
+          echo "/usr/local/opt/qt@5/bin" >> $GITHUB_PATH
+          echo LDFLAGS="-L/usr/local/opt/qt@5/lib" >> $GITHUB_ENV
+          echo CPPFLAGS="-I/usr/local/opt/qt@5/include" >> $GITHUB_ENV
+          echo PKG_CONFIG_PATH="/usr/local/opt/qt@5/lib/pkgconfig" >> $GITHUB_ENV
           # Perl module needed for help2man
           #cpan Locale::gettext
       - name: Install compiler
@@ -130,7 +134,7 @@ jobs:
       - name: Clone ASDF repo
         uses: actions/checkout@v3
         with:
-          repository:  AudioSceneDescriptionFormat/asdf-rust
+          repository: AudioSceneDescriptionFormat/asdf-rust
           submodules: true
           path: asdf-rust
       - name: Build and install ASDF library

--- a/doc/manual/building-from-source.rst
+++ b/doc/manual/building-from-source.rst
@@ -179,20 +179,14 @@ We recommend installing all dependencies from Homebrew_::
 
 You might be able to skip installing llvm if you have Xcode installed.
 
-And then::
+And then temporarily link the keg-only Qt5 according to homebrew info 
+(this is neccesary if you already have a newer version of Qt installed,
+for example if you installed the very useful package ``qjackctl``)::
 
-    brew link qt5 --force
-
-However, if you already have a newer version of Qt installed (for example if
-you installed the very useful package ``qjackctl``), you have to run this
-first::
-
-    brew unlink qt
-
-Once SSR has compiled successfully, you can switch back to the newer Qt
-version (otherwise ``qjackctl`` will not work anymore)::
-
-    brew link qt
+    export PATH="/usr/local/opt/qt@5/bin:$PATH"
+    export LDFLAGS="-L/usr/local/opt/qt@5/lib"
+    export CPPFLAGS="-I/usr/local/opt/qt@5/include"
+    export PKG_CONFIG_PATH="/usr/local/opt/qt@5/lib/pkgconfig"
 
 If you want to use ``help2man`` on macOS, you have to install a Perl package::
 


### PR DESCRIPTION
I think this is cleaner to temporarily link Qt5 from homebrew when Qt6 is also installed, with the main reason that the brew link configuration does not need to be corrected and reverted to Qt6 after building.

The GitHub Actions currently fail due to an outdated macOS+Xcode configuration as described in https://github.com/SoundScapeRenderer/ssr/issues/380. I've manually rerun a newer configuration, which was built successfully.