### PR TITLE
Remove code deprecations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -685,6 +685,9 @@ AS_IF([test x$have_warnings = xyes],
     WARNING_FLAGS="$WARNING_FLAGS -Woverloaded-virtual -Wnon-virtual-dtor"
     WARNING_FLAGS="$WARNING_FLAGS -Wwrite-strings"
 
+    dnl instead of -Wno-deprecated-declarations to silence OpenGL deprecation warnings
+    WARNING_FLAGS="$WARNING_FLAGS -DGL_SILENCE_DEPRECATION"
+
     dnl -Wall sets -Wstrict-overflow=1, we set it to 0:
     WARNING_FLAGS="$WARNING_FLAGS -Wstrict-overflow=0"
 

--- a/src/gui/quserinterface.cpp
+++ b/src/gui/quserinterface.cpp
@@ -1230,8 +1230,9 @@ void ssr::QUserInterface::wheelEvent(QWheelEvent *event)
   event->accept();
 
   // update zoom
+  int delta = event->angleDelta().y();
   _set_zoom(static_cast<int>(_zoom_factor/STDZOOMFACTOR *
-                             (100.0f+event->delta()/100.f*5.0f) + 0.5f));
+                             (100.0f+delta/100.f*5.0f) + 0.5f));
 }
 
 /** Handles Qt drag & drop events.


### PR DESCRIPTION
I saw a lot of deprecation warnings when building and figured that some of them could be eliminated. I then noticed that all the `sprintf()` deprecations come from the submodule libraries. Hence, only one warning is prevented (`delta`), and one kind of warning that occurs many times is silenced (OpenGL). The latter may be a warning exclusive to macOS (not sure).

I have quickly verified the `QWheelEvent` change (`delta`). The zoom of an `ssr-binaural` scene worked for me as before (tested on macOS). 

To see the other builds succeed, I have temporarily disabled the two failing macOS CI build configurations, as mentioned in https://github.com/SoundScapeRenderer/ssr/issues/380. These should not be merged and treated separately.