### PR TITLE
CI, PD externals, Windows: use m_amd64 extension

### DIFF
--- a/.github/workflows/pd-externals.yml
+++ b/.github/workflows/pd-externals.yml
@@ -120,11 +120,11 @@ jobs:
       - name: build externals
         working-directory: ssr/flext
         run: |
-          make install DESTDIR=build PDLIBDIR=
+          make install DESTDIR=build PDLIBDIR= extension=m_amd64
       - name: Fix dll dependencies
         working-directory: ssr/flext
         run: |
-          sh pd-lib-builder-iem-ci/localdeps/localdeps.win.sh build/ssr_*.dll
+          sh pd-lib-builder-iem-ci/localdeps/localdeps.win.sh build/ssr_*.m_amd64
       - name: upload Windows externals
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
... to clarify that 32-bit is not supported.

This has been recommended on the Pd mailing list: https://lists.puredata.info/pipermail/pd-list/2023-12/132848.html