### PR TITLE
CI: fix Python installation with brew

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,14 @@ jobs:
       - name: Install homebrew packages
         if: startsWith(matrix.os, 'macos')
         run: |
+          # This is only needed (temporarily?) for macos-12 and macos-13, see
+          # https://github.com/actions/runner-images/issues/4020
+          # Fix based on https://github.com/TeamForbiddenLLC/warfork-qfusion/pull/325:
+          brew uninstall --force azure-cli
+          brew uninstall --force aws-sam-cli
+          brew install python@3 || brew link --overwrite python@3
+          # End of fix.
+
           PACKAGES=(
             asio
             automake


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/4020.

The work-around is based on https://github.com/TeamForbiddenLLC/warfork-qfusion/pull/325.

This problem doesn't seem to to appear with `macos-14`.