### PR TITLE
CI: Update macOS matrix with latest versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,15 @@ jobs:
               CC: clang-9
               CXX: clang++-9
               CXXFLAGS: -fno-builtin
-          - os: macos-15
+          - os: macos-15-arm64 # arm64 only
             xcode: Xcode_16.0
-          - os: macos-14
+          - os: macos-14-arm64 # arm64 only
             xcode: Xcode_16.0
-          - os: macos-13
+          - os: macos-13 # Intel, arm64 available
             xcode: Xcode_15.2
-          - os: macos-13
+          - os: macos-13 # Intel, arm64 available
             xcode: Xcode_14.3.1
-          - os: macos-12
+          - os: macos-12 # Intel only
             xcode: Xcode_14.2
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env || fromJSON('{}') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
               CXX: clang++-9
               CXXFLAGS: -fno-builtin
           - os: macos-14
-            xcode: Xcode_15.4
+            xcode: Xcode_16.0
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-13

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           - os: macos-14
             xcode: Xcode_15.4
           - os: macos-13
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - os: macos-13
             xcode: Xcode_14.3.1
           - os: macos-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
               CC: clang-9
               CXX: clang++-9
               CXXFLAGS: -fno-builtin
+          - os: macos-15
+            xcode: Xcode_16.0
           - os: macos-14
             xcode: Xcode_16.0
           - os: macos-13

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           - os: macos-13
             xcode: Xcode_15.1
           - os: macos-13
-            xcode: Xcode_14.3
+            xcode: Xcode_14.3.1
           - os: macos-12
             xcode: Xcode_14.2
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,15 @@ jobs:
               CC: clang-9
               CXX: clang++-9
               CXXFLAGS: -fno-builtin
-          - os: macos-15-arm64 # arm64 only
+          - os: macos-15 # arm64
             xcode: Xcode_16.0
-          - os: macos-14-arm64 # arm64 only
+          - os: macos-14 # arm64
             xcode: Xcode_16.0
-          - os: macos-13 # Intel, arm64 available
+          - os: macos-13 # Intel
             xcode: Xcode_15.2
-          - os: macos-13 # Intel, arm64 available
+          - os: macos-13 # Intel
             xcode: Xcode_14.3.1
-          - os: macos-12 # Intel only
+          - os: macos-12 # Intel
             xcode: Xcode_14.2
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env || fromJSON('{}') }}


### PR DESCRIPTION
Mostly updating to the latest available versions and adding `macos-15` which should be available now (configurations based on https://github.com/actions/runner-images/tree/main/images/macos).  Lets see how it goes.

If you want to limit the number of jobs, we could get rid of `macos-13, Xcode_14.3.1` as it is maybe obsolete.