### PR TITLE
Rename asio::io_service to asio::io_context

### DIFF
--- a/src/fudi/server.cpp
+++ b/src/fudi/server.cpp
@@ -36,17 +36,17 @@ using asio::ip::tcp;
 
 Server::Server(api::Publisher& controller, short port)
   : _controller{controller}
-  , _io_service{}
-  , _acceptor{_io_service, tcp::endpoint(tcp::v4(), port)}
-  , _socket{_io_service}
+  , _io_context{}
+  , _acceptor{_io_context, tcp::endpoint(tcp::v4(), port)}
+  , _socket{_io_context}
 {
   _do_accept();
-  _thread = std::thread{[this](){ _io_service.run(); }};
+  _thread = std::thread{[this](){ _io_context.run(); }};
 }
 
 Server::~Server()
 {
-  _io_service.stop();
+  _io_context.stop();
   if (_thread.joinable()) { _thread.join(); }
 }
 

--- a/src/fudi/server.h
+++ b/src/fudi/server.h
@@ -48,9 +48,7 @@ private:
   void _do_accept();
 
   api::Publisher& _controller;
-  // TODO: io_context is not yet supported in Asio 1.10
-  //asio::io_context _io_context;
-  asio::io_service _io_service;
+  asio::io_context _io_context;
   asio::ip::tcp::acceptor _acceptor;
   asio::ip::tcp::socket _socket;
   std::thread _thread;

--- a/src/legacy_network/connection.cpp
+++ b/src/legacy_network/connection.cpp
@@ -34,10 +34,10 @@
 using ssr::legacy_network::Connection;
 
 /// ctor
-Connection::Connection(asio::io_service &io_service
+Connection::Connection(asio::io_context &io_context
     , api::Publisher &controller, char end_of_message_character)
-  : _socket(io_service)
-  , _timer(io_service)
+  : _socket(io_context)
+  , _timer(io_context)
   , _controller(controller)
   , _subscriber(*this)
   , _commandparser(controller)
@@ -45,15 +45,15 @@ Connection::Connection(asio::io_service &io_service
 {}
 
 /** Get an instance of Connection.
- * @param io_service
+ * @param io_context
  * @param controller used to (un)subscribe and get the actual Scene
  * @return ptr to Connection
  **/
 Connection::pointer
-Connection::create(asio::io_service &io_service
+Connection::create(asio::io_context &io_context
     , api::Publisher& controller, char end_of_message_character)
 {
-  return pointer(new Connection(io_service, controller
+  return pointer(new Connection(io_context, controller
       , end_of_message_character));
 }
 
@@ -77,7 +77,7 @@ Connection::start()
   start_read();
 
   // initialize the timer
-  _timer.expires_from_now(std::chrono::milliseconds(100));
+  _timer.expires_after(std::chrono::milliseconds(100));
   _timer.async_wait(std::bind(&Connection::timeout_handler, shared_from_this()
         , std::placeholders::_1));
 }
@@ -94,7 +94,7 @@ Connection::timeout_handler(const asio::error_code &e)
   if (e) return;
 
   // Set timer again.
-  _timer.expires_from_now(std::chrono::milliseconds(100));
+  _timer.expires_after(std::chrono::milliseconds(100));
   _timer.async_wait(std::bind(&Connection::timeout_handler, shared_from_this()
         , std::placeholders::_1));
 }

--- a/src/legacy_network/connection.h
+++ b/src/legacy_network/connection.h
@@ -60,7 +60,7 @@ class Connection : public std::enable_shared_from_this<Connection>
     typedef std::shared_ptr<Connection> pointer;
     typedef asio::ip::tcp::socket socket_t;
 
-    static pointer create(asio::io_service &io_service
+    static pointer create(asio::io_context &io_context
         , api::Publisher &controller, char end_of_message_character);
 
     void start();
@@ -72,7 +72,7 @@ class Connection : public std::enable_shared_from_this<Connection>
     unsigned int get_source_number(id_t source_id) const;
 
   private:
-    Connection(asio::io_service &io_service, api::Publisher &controller
+    Connection(asio::io_context &io_context, api::Publisher &controller
         , char end_of_message_character);
 
     void start_read();

--- a/src/legacy_network/server.cpp
+++ b/src/legacy_network/server.cpp
@@ -39,8 +39,8 @@ Server::Server(api::Publisher& controller
     , int port, char end_of_message_character)
   : _controller(controller)
   , _scene_provider(scene_provider)
-  , _io_service()
-  , _acceptor(_io_service
+  , _io_context()
+  , _acceptor(_io_context
       , asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port))
   , _network_thread(0)
   , _end_of_message_character(end_of_message_character)
@@ -54,7 +54,7 @@ Server::~Server()
 void
 Server::start_accept()
 {
-  Connection::pointer new_connection = Connection::create(_io_service
+  Connection::pointer new_connection = Connection::create(_io_context
       , _controller, _end_of_message_character);
 
   _acceptor.async_accept(new_connection->socket()
@@ -87,7 +87,7 @@ Server::stop()
   SSR_VERBOSE2("Stopping network thread ...");
   if (_network_thread)
   {
-    _io_service.stop();
+    _io_context.stop();
     _network_thread->join();
   }
   SSR_VERBOSE2("Network thread stopped.");
@@ -97,5 +97,5 @@ void
 Server::run()
 {
   start_accept();
-  _io_service.run();
+  _io_context.run();
 }

--- a/src/legacy_network/server.h
+++ b/src/legacy_network/server.h
@@ -71,7 +71,7 @@ class Server
     api::Publisher& _controller;
     // Just a hack for get_scene_as_XML():
     LegacyXmlSceneProvider& _scene_provider;
-    asio::io_service _io_service;
+    asio::io_context _io_context;
     asio::ip::tcp::acceptor _acceptor;
     std::thread *_network_thread;
 


### PR DESCRIPTION
asio renamed the class in 1.12.0 and removed backwards compatibility in 1.33.0.

Fixes https://github.com/SoundScapeRenderer/ssr/issues/412.